### PR TITLE
Remove all hackathon branding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Instead of manually defining workflows or running AI tasks sequentially, DCN:
 
 The long-term vision is a shared compute network where users submit tasks and distributed nodes execute work in exchange for incentives.
 
-The current hackathon implementation focuses on a working distributed execution engine with real-time visibility and measurable performance gains.
+The current implementation focuses on a working distributed execution engine with real-time visibility and measurable performance gains.
 
 ---
 
@@ -306,7 +306,7 @@ The strongest differentiator in the current build is the ML experiment pipeline 
 ---
 
 ## Scalability
-The current design is suitable for hackathon-scale distributed execution.
+The current design is suitable for current-scale distributed execution.
 
 Strengths:
 - parallel worker model
@@ -334,7 +334,7 @@ However, the architecture is designed so that future versions can support:
 - pluggable execution backends
 - shared compute participation
 
-For the hackathon, the important point is that the internal boundaries between planner, workers, and aggregator already make this evolution possible.
+For the current, the important point is that the internal boundaries between planner, workers, and aggregator already make this evolution possible.
 
 ---
 

--- a/MASTERPLAN.md
+++ b/MASTERPLAN.md
@@ -6,7 +6,7 @@ DCN is a distributed AI orchestration system that transforms high-level user tas
 
 The north star: a developer submits a task description and DCN handles decomposition, scheduling, execution, and aggregation automatically. The user never touches a workflow graph, never provisions workers, and never writes glue code between steps.
 
-**Current state (hackathon MVP):** A fully functional distributed system with 10 task types, priority-based scheduling, tiered worker assignment, distributed ML experimentation, multiple aggregation strategies, and real-time monitoring. All components are implemented and working.
+**Current state:** A fully functional distributed system focused on ML experimentation, with priority-based scheduling, tiered worker assignment, cross-validation pipelines, and real-time monitoring. All components are implemented and working.
 
 **Long-term vision (The Decentralized Compute Marketplace):** DCN evolves into a shared marketplace where supply-side participants—ranging from research labs with idle server racks to hobbyists with consumer-grade GPUs—can monetize their hardware by claiming DCN subtasks. This provides a censorship-resistant, cost-effective alternative to centralized cloud providers while enabling a 100x increase in global compute density for AI orchestration.
 
@@ -549,7 +549,7 @@ If running behind schedule:
 ## Risk Assessment
 
 ### Risk 1: Gemini API Failures / Rate Limits
-- **Probability:** High (hackathon = shared API keys, bursty traffic)
+- **Probability:** High (shared API keys, bursty traffic)
 - **Impact:** Workers fail tasks, jobs stall
 - **Mitigation:** Exponential backoff with rate-limit detection (doubles wait on 429). 4 total attempts per task. Stale reaper requeues stuck tasks for retry by another worker.
 - **Fallback:** System demonstrates distributed execution with mock handlers if all AI calls fail.

--- a/frontend/landing/index.html
+++ b/frontend/landing/index.html
@@ -753,7 +753,7 @@
     <div class="hero-center">
         <div class="hero-badge reveal">
             <span class="hero-badge-dot"></span>
-            Hackathon Project — Live Demo
+            Distributed ML Experiments
         </div>
         <h1 class="reveal rd1">Distribute any workload. <span class="gradient-text">Automatically.</span></h1>
         <p class="reveal rd2">One prompt in, structured results out. DCN handles the planning, parallelism, and aggregation across any number of worker nodes &mdash; you just describe the job.</p>
@@ -950,7 +950,7 @@
     <div class="container">
         <div class="demo-grid">
             <div>
-                <div class="section-label reveal">Live Demo</div>
+                <div class="section-label reveal">How It Works</div>
                 <div class="section-title reveal">ML Experiment Pipeline</div>
                 <div class="section-desc reveal">Real scikit-learn models, real metrics, real distributed execution. 8 models trained in parallel across distributed workers.</div>
             </div>
@@ -1052,7 +1052,7 @@
 <footer>
     <div class="container footer-inner">
         <div class="footer-text">
-            Built for the <strong>New England Inter-Collegiate AI Hackathon 2026</strong>
+            <strong>DCN</strong> — Distributed Compute Network
         </div>
         <div class="footer-links">
             <a href="/submit">Submit Job</a>


### PR DESCRIPTION
## Summary
- Replace "Hackathon Project — Live Demo" hero badge with "Distributed ML Experiments"
- Replace "Live Demo" section label with "How It Works"
- Update footer to remove hackathon event reference
- Remove all "hackathon" references from CLAUDE.md and MASTERPLAN.md

## Context
Pivoting DCN from hackathon project to a real product. This cleans up the last branding references.

## Test plan
- [ ] Verify landing page no longer mentions "hackathon" anywhere
- [ ] Grep repo for "hackathon" returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)