### PR TITLE
UI: Submit page refresh + OpenML job submit fix

### DIFF
--- a/backend/apis/jobs.py
+++ b/backend/apis/jobs.py
@@ -91,7 +91,10 @@ async def create_job(job: JobCreate, request: Request) -> dict:
             )
 
             # Plan and insert subtasks
-            subtasks = plan_tasks(job.task_type, job.input_payload)
+            try:
+                subtasks = plan_tasks(job.task_type, job.input_payload)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
             for i, task in enumerate(subtasks, start=1):
                 await conn.execute(
                     """

--- a/backend/datasets.py
+++ b/backend/datasets.py
@@ -255,12 +255,13 @@ def _coerce_rows_numeric(rows: list[dict], features: list[str], target: str) -> 
     return clean
 
 
-def load_openml(dataset_id: str | int) -> tuple[list[dict], dict]:
-    """Fetch a dataset from OpenML by numeric ID. Returns (rows, metadata)."""
-    cache_key = f"openml:{dataset_id}"
-    if cache_key in _external_cache:
-        return _external_cache[cache_key]
+def load_openml(dataset_id: str | int, target: str | None = None) -> tuple[list[dict], dict]:
+    """Fetch a dataset from OpenML by numeric ID. Returns (rows, metadata).
 
+    Non-numeric feature columns are label-encoded so classification datasets
+    with mostly categorical inputs (e.g. monks-problems) still have usable features.
+    """
+    import pandas as pd
     import openml
 
     ds = openml.datasets.get_dataset(
@@ -270,40 +271,66 @@ def load_openml(dataset_id: str | int) -> tuple[list[dict], dict]:
         download_features_meta_data=True,
     )
 
-    X, y, _, attr_names = ds.get_data(dataset_format="dataframe")
+    X, y, _, _ = ds.get_data(dataset_format="dataframe")
 
-    target = ds.default_target_attribute or X.columns[-1]
-    if target in X.columns:
+    default_t = ds.default_target_attribute
+    if isinstance(default_t, list):
+        default_t = default_t[0] if default_t else None
+    resolved_target = target or default_t
+    if resolved_target is None and len(X.columns):
+        resolved_target = X.columns[-1]
+    if resolved_target is None:
+        raise ValueError(f"OpenML dataset {dataset_id} has no target column")
+
+    if resolved_target in X.columns:
         df = X.copy()
     else:
         df = X.copy()
-        df[target] = y
+        df[resolved_target] = y
 
-    numeric_cols = list(df.select_dtypes(include=["number"]).columns)
-    if target not in numeric_cols:
-        numeric_cols.append(target)
+    if resolved_target not in df.columns:
+        raise ValueError(
+            f"Target column '{resolved_target}' not found in OpenML dataset {dataset_id}"
+        )
 
-    features = [c for c in numeric_cols if c != target]
-    if not features:
-        raise ValueError(f"OpenML dataset {dataset_id} has no numeric feature columns")
+    feature_cols = [c for c in df.columns if c != resolved_target]
+    if not feature_cols:
+        raise ValueError(f"OpenML dataset {dataset_id} has no feature columns")
 
-    df = df[features + [target]].dropna()
+    cache_key = f"openml:{dataset_id}:{resolved_target}"
+    if cache_key in _external_cache:
+        return _external_cache[cache_key]
 
-    if len(df) > MAX_ROWS:
-        df = df.sample(n=MAX_ROWS, random_state=42)
+    work = df[feature_cols + [resolved_target]].dropna(how="any")
+    if work.empty:
+        raise ValueError(f"OpenML dataset {dataset_id} has no rows after dropping NaNs")
 
-    rows = df.to_dict("records")
-    for r in rows:
-        for c in features + [target]:
-            r[c] = float(r[c])
+    if len(work) > MAX_ROWS:
+        work = work.sample(n=MAX_ROWS, random_state=42)
 
-    y_vals = [r[target] for r in rows]
-    task_category = _infer_task_category(y_vals, target)
+    # Infer regression vs classification from target (before encoding)
+    y_series = work[resolved_target]
+    if pd.api.types.is_numeric_dtype(y_series):
+        y_vals = y_series.astype(float).tolist()[:5000]
+    else:
+        y_vals = pd.factorize(y_series)[0].tolist()[:5000]
+    task_category = _infer_task_category(y_vals, resolved_target)
+
+    # Encode categoricals so sklearn always sees numeric matrices
+    work_enc = work.copy()
+    for col in work_enc.columns:
+        s = work_enc[col]
+        if pd.api.types.is_numeric_dtype(s):
+            work_enc[col] = s.astype(float)
+        else:
+            work_enc[col] = pd.factorize(s)[0].astype(float)
+
+    rows = work_enc.to_dict("records")
 
     meta = {
-        "target": target,
+        "target": resolved_target,
         "task_category": task_category,
-        "all_features": features,
+        "all_features": feature_cols,
         "display_name": ds.name or f"OpenML #{dataset_id}",
         "description": (ds.description or "")[:200],
     }
@@ -366,7 +393,7 @@ def load_external_dataset(
 ) -> tuple[list[dict], dict]:
     """Unified loader that dispatches by source type."""
     if source == "openml":
-        return load_openml(dataset_id)
+        return load_openml(dataset_id, target=target)
     elif source == "csv_url":
         return load_csv_url(dataset_id, target=target)
     elif source == "built_in":

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,4 +7,5 @@ httpx
 google-genai
 scikit-learn
 numpy
+pandas
 openml


### PR DESCRIPTION
## Summary
- **Frontend:** Modernized Submit Job layout (segmented dataset source, secondary Load, violet-forward styling, localhost preview without redirect to `/login`).
- **Backend:** OpenML datasets with only categorical features (or a single numeric target) no longer crash job planning with a 500. Non-numeric columns are label-encoded; selected target is respected. Planning `ValueError` maps to HTTP 400. Adds explicit `pandas` dependency.

## Test plan
- [ ] Submit built-in RI Weather job
- [ ] OpenML ID `334`, target `class`, Load then Submit
- [ ] Local static preview at `python -m http.server` still shows form without login redirect


Made with [Cursor](https://cursor.com)