### PR TITLE
fix(db): jobs.user_id FK must reference dcn_users (OAuth)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -85,6 +85,75 @@ async def _maintenance_loop():
             logger.error("Maintenance loop error: %s", e, exc_info=True)
 
 
+async def _migrate_jobs_user_fk_to_dcn_users(conn) -> None:
+    """
+    Legacy Supabase schemas often have jobs.user_id → users(id).
+    OAuth uses dcn_users; session user IDs are not in users, causing FK violations on INSERT.
+    Drop FK to users and attach jobs.user_id → dcn_users(id).
+    """
+    jobs_exists = await conn.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'jobs'
+        )
+        """
+    )
+    if not jobs_exists:
+        return
+
+    legacy_fks = await conn.fetch(
+        """
+        SELECT con.conname::text AS name
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+        JOIN pg_class ref ON ref.oid = con.confrelid
+        WHERE nsp.nspname = 'public'
+          AND rel.relname = 'jobs'
+          AND con.contype = 'f'
+          AND ref.relname = 'users'
+        """
+    )
+    for row in legacy_fks:
+        await conn.execute(f'ALTER TABLE jobs DROP CONSTRAINT "{row["name"]}"')
+        logger.info("Dropped legacy jobs.user_id FK to public.users: %s", row["name"])
+
+    has_dcn_fk = await conn.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_constraint con
+            JOIN pg_class rel ON rel.oid = con.conrelid
+            JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+            JOIN pg_class ref ON ref.oid = con.confrelid
+            WHERE nsp.nspname = 'public'
+              AND rel.relname = 'jobs'
+              AND con.contype = 'f'
+              AND ref.relname = 'dcn_users'
+        )
+        """
+    )
+    if has_dcn_fk:
+        return
+
+    await conn.execute(
+        """
+        UPDATE jobs SET user_id = NULL
+        WHERE user_id IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM dcn_users u WHERE u.id = jobs.user_id)
+        """
+    )
+    await conn.execute(
+        """
+        ALTER TABLE jobs
+        ADD CONSTRAINT jobs_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES dcn_users(id) ON DELETE SET NULL
+        """
+    )
+    logger.info("Added jobs.user_id foreign key to dcn_users")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Start up: connect to DB, create static cache table, + start maintenance. Shut down: clean up."""
@@ -124,6 +193,11 @@ async def lifespan(app: FastAPI):
             );
             """
         )
+        try:
+            await _migrate_jobs_user_fk_to_dcn_users(conn)
+        except Exception as e:
+            logger.error("jobs.user_id FK migration failed: %s", e, exc_info=True)
+            raise
     maintenance_task = asyncio.create_task(_maintenance_loop())
     yield
     maintenance_task.cancel()

--- a/schema.sql
+++ b/schema.sql
@@ -5,6 +5,8 @@
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- ─── Jobs ───────────────────────────────────────────────
+-- user_id must reference dcn_users(id) when using OAuth (see backend/main.py migration).
+-- Legacy DBs may still point at public.users; startup migrates that FK.
 CREATE TABLE IF NOT EXISTS jobs (
     id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id             UUID,


### PR DESCRIPTION
## Problem
`POST /jobs` failed with:
`ForeignKeyViolationError: insert or update on table "jobs" violates foreign key constraint "jobs_user_id_fkey" ... Key (user_id)=(...) is not present in table "users".`

OAuth stores users in `dcn_users`, but legacy DBs (e.g. Supabase) had `jobs.user_id` referencing `public.users`.

## Fix
On startup, drop any `jobs` → `users` foreign key and add `jobs.user_id` → `dcn_users(id) ON DELETE SET NULL`, after nulling `user_id` on rows that do not match any `dcn_users` row.

## Deploy
Merge and redeploy Render; migration runs automatically on boot.

Made with [Cursor](https://cursor.com)