### PR TITLE
fix: Clear all jobs for CEO + credentials on ops

### DIFF
--- a/backend/apis/jobs.py
+++ b/backend/apis/jobs.py
@@ -139,10 +139,12 @@ async def get_job_tasks(job_id: str) -> list[dict]:
 
 @router.delete("/jobs/all")
 async def clear_all_jobs(request: Request) -> dict:
-    """Delete all jobs, tasks, events, and results. Admin-only demo reset."""
+    """Delete all jobs, tasks, events, and results. CEO or admin demo reset."""
     user = await get_session(request)
-    if not user or user.get("role") != "admin":
-        raise HTTPException(status_code=403, detail="Admin access required")
+    if not user or user.get("role") not in ELEVATED_ROLES:
+        raise HTTPException(
+            status_code=403, detail="CEO or admin access required"
+        )
     pool = await get_pool()
     async with pool.acquire() as conn:
         await conn.execute("DELETE FROM task_results")

--- a/frontend/monitor/index.html
+++ b/frontend/monitor/index.html
@@ -1050,15 +1050,28 @@
   async function clearAllJobs() {
     if (!confirm('Clear all jobs, tasks, and results? This cannot be undone.')) return;
     try {
-      const resp = await fetch('/jobs/all', { method: 'DELETE' });
-      if (resp.ok) {
-        selectedJobId = null;
-        allJobs = [];
-        lastDetailHash = null;
-        lastEventHash = null;
-        hasAutoSelected = false;
-        pollAll();
+      const resp = await fetch('/jobs/all', {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      const text = await resp.text();
+      if (!resp.ok) {
+        let msg = text.slice(0, 400);
+        try {
+          const j = JSON.parse(text);
+          if (j.detail !== undefined) {
+            msg = typeof j.detail === 'string' ? j.detail : JSON.stringify(j.detail);
+          }
+        } catch (_) {}
+        alert(msg || 'Clear failed');
+        return;
       }
+      selectedJobId = null;
+      allJobs = [];
+      lastDetailHash = null;
+      lastEventHash = null;
+      hasAutoSelected = false;
+      pollAll();
     } catch (e) {
       alert('Failed to clear: ' + e.message);
     }


### PR DESCRIPTION
Previously only `role == admin` could call `DELETE /jobs/all`; CEOs got 403 with no UI feedback. Now matches elevated access elsewhere; monitor shows error `detail` if the request fails.

Made with [Cursor](https://cursor.com)