### PR TITLE
fix: task UI progress, validation default, OpenML column keys

### DIFF
--- a/backend/apis/monitor.py
+++ b/backend/apis/monitor.py
@@ -66,12 +66,18 @@ async def monitor_stats() -> dict:
         )
         worker_counts = {r["effective_status"]: r["count"] for r in worker_rows}
 
+    # Count worker-finished tasks (submitted + awaiting admin validation)
+    finished_tasks = task_counts.get("submitted", 0) + task_counts.get(
+        "pending_validation", 0
+    )
+
     return {
         "total_jobs": sum(job_counts.values()),
         "completed_jobs": job_counts.get("completed", 0),
         "queued_tasks": task_counts.get("queued", 0),
         "running_tasks": task_counts.get("running", 0),
-        "submitted_tasks": task_counts.get("submitted", 0),
+        "submitted_tasks": finished_tasks,
+        "pending_validation_tasks": task_counts.get("pending_validation", 0),
         "online_workers": worker_counts.get("online", 0),
         "busy_workers": worker_counts.get("busy", 0),
     }

--- a/backend/datasets.py
+++ b/backend/datasets.py
@@ -288,12 +288,16 @@ def load_openml(dataset_id: str | int, target: str | None = None) -> tuple[list[
         df = X.copy()
         df[resolved_target] = y
 
+    # JSONB task payloads and sklearn need stable string column names (avoid attr1 KeyErrors)
+    df = df.rename(columns={c: str(c) for c in df.columns})
+    resolved_target = str(resolved_target)
+
     if resolved_target not in df.columns:
         raise ValueError(
             f"Target column '{resolved_target}' not found in OpenML dataset {dataset_id}"
         )
 
-    feature_cols = [c for c in df.columns if c != resolved_target]
+    feature_cols = [str(c) for c in df.columns if str(c) != resolved_target]
     if not feature_cols:
         raise ValueError(f"OpenML dataset {dataset_id} has no feature columns")
 

--- a/backend/handlers/ml_experiment.py
+++ b/backend/handlers/ml_experiment.py
@@ -63,14 +63,31 @@ def handle(task: dict, job: dict) -> str:
     if not features:
         features = meta["all_features"]
 
+    # Planner/JSON may use string keys; OpenML columns are normalized to str in datasets.load_openml
+    features = [str(f) for f in features]
+    target = str(target)
+
+    sample = rows[0] if rows else {}
+    missing = [f for f in features if f not in sample]
+    if missing:
+        return (
+            f"Dataset column mismatch: features not in rows — {missing[:5]}"
+            f"{'…' if len(missing) > 5 else ''}. Available keys: {list(sample.keys())[:20]}"
+        )
+    if target not in sample:
+        return f"Target column '{target}' not found in dataset rows. Keys: {list(sample.keys())[:30]}"
+
     max_rows = safe_dataset_size(len(rows))
     if max_rows < len(rows):
         import random
         rows = random.sample(rows, max_rows)
 
+    def _cell(row, key):
+        return row[key] if key in row else row[str(key)]
+
     # Build X and y as numpy arrays for speed
-    X = np.array([[row[f] for f in features] for row in rows])
-    y = np.array([row[target] for row in rows])
+    X = np.array([[_cell(row, f) for f in features] for row in rows])
+    y = np.array([_cell(row, target) for row in rows])
 
     # Train/test split (hold out 20% for final eval after CV)
     X_train, X_test, y_train, y_test = train_test_split(

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -10,7 +10,7 @@ class JobCreate(BaseModel):
     user_id: Optional[str] = None
     priority: int = 1
     reward_amount: float = 0.00
-    requires_validation: bool = True
+    requires_validation: bool = False
 
 
 class TaskClaim(BaseModel):

--- a/frontend/monitor/index.html
+++ b/frontend/monitor/index.html
@@ -1084,6 +1084,10 @@
 
   function badge(status) {
     const s = (status || 'unknown').toLowerCase();
+    // Worker finished but job still requires_validation — show as done, not "running"
+    if (s === 'pending_validation') {
+      return '<span class="badge badge-submitted" title="Awaiting admin validation">pending validation</span>';
+    }
     return `<span class="badge badge-${s}">${s}</span>`;
   }
 
@@ -1249,8 +1253,10 @@
     if (hash === lastDetailHash) return;  // nothing changed, skip re-render
     lastDetailHash = hash;
 
-    // Compute progress
-    const submitted = (tasks || []).filter(t => t.status === 'submitted').length;
+    // Compute progress (pending_validation = worker done, same as submitted for UI)
+    const submitted = (tasks || []).filter(t =>
+      t.status === 'submitted' || t.status === 'pending_validation'
+    ).length;
     const running = (tasks || []).filter(t => t.status === 'running').length;
     const total = (tasks || []).length;
     const pct = total > 0 ? Math.round((submitted / total) * 100) : 0;

--- a/frontend/my-jobs/index.html
+++ b/frontend/my-jobs/index.html
@@ -312,7 +312,9 @@ async function loadTasksForCard(job) {
   try {
     const resp = await fetch(`${API}/jobs/${job.id}/tasks`, { credentials: 'include' });
     const tasks = await resp.json();
-    const done = tasks.filter(t => t.status === 'submitted').length;
+    const done = tasks.filter(t =>
+      t.status === 'submitted' || t.status === 'pending_validation'
+    ).length;
     const pct = tasks.length > 0 ? (done / tasks.length) * 100 : 0;
     const bar = document.getElementById(`pbar-${job.id}`);
     if (bar) {

--- a/frontend/public_page/index.html
+++ b/frontend/public_page/index.html
@@ -1282,11 +1282,13 @@
 
         const resp = await fetch(`${API}/jobs`, {
           method: 'POST',
+          credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             title: title,
             task_type: taskType,
             input_payload: payload,
+            requires_validation: false,
           }),
         });
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -69,7 +69,7 @@ class TestSchemas:
         job = JobCreate(title="Test", task_type="ml_experiment")
         assert job.priority == 1
         assert job.reward_amount == 0.0
-        assert job.requires_validation is True
+        assert job.requires_validation is False
         assert job.input_payload == {}
 
     def test_job_create_with_payload(self):


### PR DESCRIPTION
## Root causes
1. **Ops showed RUNNING / 0%** — `requires_validation` defaulted to **true**, so completed tasks became `pending_validation` instead of `submitted`. The dashboard only counted `submitted` and had no badge style for `pending_validation`.
2. **`attr1`-style errors** — OpenML/pandas column names were not always normalized to **strings**, so JSONB round-trips and row access could mismatch keys.

## Changes
- `JobCreate.requires_validation` default **false**; submit form sends it explicitly + `credentials: 'include'`.
- Monitor + My Jobs: treat `pending_validation` as finished for progress; badge shows “pending validation” with submitted styling.
- Monitor stats: `submitted_tasks` includes `pending_validation`; add `pending_validation_tasks`.
- `load_openml`: `rename` columns to `str`; `ml_experiment`: str features/target, validate keys, safe `_cell` access.

**Deploy:** merge + redeploy API + worker using this repo’s `handlers` + `datasets` (if you mirror `dcn-worker`, sync those files).

Made with [Cursor](https://cursor.com)