### PR TITLE
fix(ops): show failure reason in task table

### DIFF
--- a/backend/apis/jobs.py
+++ b/backend/apis/jobs.py
@@ -127,11 +127,23 @@ async def create_job(job: JobCreate, request: Request) -> dict:
 
 @router.get("/jobs/{job_id}/tasks")
 async def get_job_tasks(job_id: str) -> list[dict]:
-    """Return all tasks for a job, ordered by task_order."""
+    """Return all tasks for a job, ordered by task_order, with optional failure_detail from task_results."""
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            "SELECT * FROM job_tasks WHERE job_id = $1 ORDER BY task_order",
+            """
+            SELECT jt.*, sub.result_text AS failure_detail
+            FROM job_tasks jt
+            LEFT JOIN LATERAL (
+                SELECT result_text
+                FROM task_results
+                WHERE task_id = jt.id
+                ORDER BY submitted_at DESC
+                LIMIT 1
+            ) sub ON TRUE
+            WHERE jt.job_id = $1
+            ORDER BY jt.task_order
+            """,
             job_id,
         )
     return [dict(r) for r in rows]

--- a/backend/apis/workers.py
+++ b/backend/apis/workers.py
@@ -293,6 +293,18 @@ async def fail_task(task_id: str, body: TaskFail = TaskFail()) -> dict:
             msg,
         )
 
+        # Store on task_results so job detail table can show the reason (not just "failed")
+        await conn.execute("DELETE FROM task_results WHERE task_id = $1", task_id)
+        await conn.execute(
+            """
+            INSERT INTO task_results (task_id, worker_node_id, result_text, result_payload, status)
+            VALUES ($1, $2, $3, '{}'::jsonb, 'failed')
+            """,
+            task_id,
+            task["worker_node_id"],
+            msg,
+        )
+
         # If all tasks are terminal (submitted or failed), mark job as failed
         counts = await conn.fetchrow(
             """

--- a/frontend/monitor/index.html
+++ b/frontend/monitor/index.html
@@ -520,6 +520,16 @@
     .event-item[data-type="task_started"]::before { background: #eab308; }
     .event-item[data-type="task_submitted"]::before { background: #22c55e; }
     .event-item[data-type="task_failed"]::before { background: #ef4444; }
+    .task-fail-detail {
+      font-size: 0.68rem;
+      color: rgba(248, 180, 180, 0.95);
+      max-width: min(420px, 36vw);
+      white-space: pre-wrap;
+      word-break: break-word;
+      margin-top: 6px;
+      line-height: 1.35;
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+    }
     .event-item[data-type="job_completed"]::before { background: #22c55e; }
 
     /* Mono IDs */
@@ -1229,6 +1239,14 @@
   }
 
   // --- Load Job Detail ---
+  function taskFailureHtml(t) {
+    const st = (t.status || '').toLowerCase();
+    if (st !== 'failed' || !t.failure_detail) return '';
+    const raw = String(t.failure_detail);
+    const preview = raw.length > 600 ? raw.slice(0, 600) + '…' : raw;
+    return `<div class="task-fail-detail">${escapeHtml(preview)}</div>`;
+  }
+
   async function loadJobDetail() {
     const el = document.getElementById('job-detail');
     if (!selectedJobId) {
@@ -1289,7 +1307,7 @@
           <td>${t.task_order != null ? t.task_order : '-'}</td>
           <td>${t.task_name || '-'}</td>
           <td>${tierBadge(t)}</td>
-          <td>${badge(t.status)}</td>
+          <td>${badge(t.status)}${taskFailureHtml(t)}</td>
           <td class="mono">${t.worker_node_id ? shortId(t.worker_node_id) : '-'}</td>
         </tr>`;
       });
@@ -1397,7 +1415,7 @@
     el.innerHTML = '<div class="event-feed-container">' + events.map(e => `
       <div class="event-item" data-type="${e.event_type || ''}">
         <div class="event-type">${e.event_type || '-'}</div>
-        <div class="event-msg">${e.message || ''}</div>
+        <div class="event-msg">${escapeHtml(e.message || '')}</div>
         <div class="event-time">${formatTime(e.created_at)}</div>
       </div>
     `).join('') + '</div>';


### PR DESCRIPTION
Failed tasks only showed badge text **failed**. Error text is now stored on task_results and shown under the status column. Event feed messages are HTML-escaped.

Made with [Cursor](https://cursor.com)