### PR TITLE
fix: external datasets — OpenML/CSV preview, target picker, pandas CSV

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -153,4 +153,6 @@ ADMIN_API_PREFIXES = ["/monitor/"]
 # Pages that require any authenticated user (non-admin)
 AUTH_REQUIRED_PAGES = {"/submit"}
 # Prefixes that don't need auth
-PUBLIC_PREFIXES = ["/login", "/health", "/workers/", "/tasks/", "/jobs", "/auth/", "/stats", "/my-jobs"]
+PUBLIC_PREFIXES = [
+    "/login", "/health", "/workers/", "/tasks/", "/jobs", "/auth/", "/stats", "/my-jobs", "/datasets",
+]

--- a/backend/datasets.py
+++ b/backend/datasets.py
@@ -12,7 +12,6 @@ models (50k-100k rows, 15+ features, polynomial interactions).
 
 import random
 import math
-import csv
 import io
 import logging
 
@@ -227,34 +226,6 @@ def _infer_task_category(y_values: list, target_name: str) -> str:
     return "classification"
 
 
-def _numeric_columns(rows: list[dict]) -> list[str]:
-    """Return column names where all sampled values are numeric."""
-    if not rows:
-        return []
-    sample = rows[:200]
-    numeric = []
-    for col in rows[0].keys():
-        try:
-            for r in sample:
-                float(r[col])
-            numeric.append(col)
-        except (ValueError, TypeError, KeyError):
-            continue
-    return numeric
-
-
-def _coerce_rows_numeric(rows: list[dict], features: list[str], target: str) -> list[dict]:
-    """Convert feature + target values to float, dropping rows that fail."""
-    cols = set(features) | {target}
-    clean = []
-    for r in rows:
-        try:
-            clean.append({c: float(r[c]) for c in cols})
-        except (ValueError, TypeError, KeyError):
-            continue
-    return clean
-
-
 def load_openml(dataset_id: str | int, target: str | None = None) -> tuple[list[dict], dict]:
     """Fetch a dataset from OpenML by numeric ID. Returns (rows, metadata).
 
@@ -343,50 +314,66 @@ def load_openml(dataset_id: str | int, target: str | None = None) -> tuple[list[
 
 
 def load_csv_url(url: str, target: str | None = None) -> tuple[list[dict], dict]:
-    """Download a CSV from a public URL. Returns (rows, metadata)."""
+    """Download a CSV from a public URL. Returns (rows, metadata).
+
+    Non-numeric columns are label-encoded like OpenML so typical public CSVs work
+    without requiring all-numeric inputs.
+    """
     cache_key = f"csv:{url}:{target}"
     if cache_key in _external_cache:
         return _external_cache[cache_key]
 
     import httpx
+    import pandas as pd
 
     resp = httpx.get(url, follow_redirects=True, timeout=60)
     resp.raise_for_status()
 
-    text = resp.text
-    reader = csv.DictReader(io.StringIO(text))
-    all_rows = list(reader)
-    if not all_rows:
+    df = pd.read_csv(io.StringIO(resp.text))
+    if df.empty:
         raise ValueError("CSV is empty or could not be parsed")
+    df.columns = [str(c).strip() for c in df.columns]
 
-    numeric = _numeric_columns(all_rows)
-    if not numeric:
-        raise ValueError("CSV has no numeric columns")
+    resolved_target = str(target) if target else str(df.columns[-1])
+    if resolved_target not in df.columns:
+        raise ValueError(
+            f"Target column '{resolved_target}' not found. Columns: {list(df.columns)}"
+        )
 
-    if target and target not in numeric:
-        raise ValueError(f"Target '{target}' is not a numeric column. Numeric columns: {numeric}")
+    feature_cols = [c for c in df.columns if c != resolved_target]
+    if not feature_cols:
+        raise ValueError("No feature columns after selecting target")
 
-    if not target:
-        target = numeric[-1]
+    work = df[feature_cols + [resolved_target]].dropna(how="any")
+    if work.empty:
+        raise ValueError("CSV has no rows after dropping NaNs")
 
-    features = [c for c in numeric if c != target]
-    if not features:
-        raise ValueError("No feature columns remaining after selecting target")
+    if len(work) > MAX_ROWS:
+        work = work.sample(n=MAX_ROWS, random_state=42)
 
-    rows = _coerce_rows_numeric(all_rows, features, target)
+    y_series = work[resolved_target]
+    if pd.api.types.is_numeric_dtype(y_series):
+        y_vals = y_series.astype(float).tolist()[:5000]
+    else:
+        y_vals = pd.factorize(y_series)[0].tolist()[:5000]
+    task_category = _infer_task_category(y_vals, resolved_target)
 
-    if len(rows) > MAX_ROWS:
-        rows = random.sample(rows, MAX_ROWS)
+    work_enc = work.copy()
+    for col in work_enc.columns:
+        s = work_enc[col]
+        if pd.api.types.is_numeric_dtype(s):
+            work_enc[col] = s.astype(float)
+        else:
+            work_enc[col] = pd.factorize(s)[0].astype(float)
 
-    y_vals = [r[target] for r in rows]
-    task_category = _infer_task_category(y_vals, target)
+    rows = work_enc.to_dict("records")
 
     meta = {
-        "target": target,
+        "target": resolved_target,
         "task_category": task_category,
-        "all_features": features,
+        "all_features": feature_cols,
         "display_name": url.split("/")[-1][:60] or "CSV Dataset",
-        "description": f"{len(rows):,} rows, {len(features)} features",
+        "description": f"{len(rows):,} rows, {len(feature_cols)} features",
     }
     _external_cache[cache_key] = (rows, meta)
     return rows, meta
@@ -417,9 +404,11 @@ def preview_dataset(
         if dataset_id not in DATASETS:
             raise ValueError(f"Unknown built-in dataset: {dataset_id}")
         info = DATASETS[dataset_id]
+        cols = info["all_features"] + [info["target"]]
         return {
-            "columns": info["all_features"] + [info["target"]],
-            "numeric_columns": info["all_features"] + [info["target"]],
+            "columns": cols,
+            "numeric_columns": cols,
+            "target_columns": cols,
             "row_count": 75_000,
             "sample_rows": [],
             "suggested_target": info["target"],
@@ -429,6 +418,7 @@ def preview_dataset(
 
     if source == "openml":
         import openml
+        import pandas as pd
 
         ds = openml.datasets.get_dataset(
             int(dataset_id),
@@ -437,19 +427,30 @@ def preview_dataset(
             download_features_meta_data=True,
         )
         X, y, _, _ = ds.get_data(dataset_format="dataframe")
-        target = ds.default_target_attribute or X.columns[-1]
+        raw_t = ds.default_target_attribute
+        if isinstance(raw_t, (list, tuple)):
+            raw_t = raw_t[0] if raw_t else None
+        target = str(raw_t) if raw_t is not None else str(X.columns[-1])
+        X = X.rename(columns={c: str(c) for c in X.columns})
+        target = str(target)
         if target not in X.columns:
+            X = X.copy()
             X[target] = y
         numeric = list(X.select_dtypes(include=["number"]).columns)
         if target not in numeric:
             numeric.append(target)
-        all_cols = list(X.columns)
+        all_cols = [str(c) for c in X.columns]
         sample = X.head(5).to_dict("records")
-        y_vals = X[target].dropna().tolist()[:5000]
+        y_series = X[target].dropna()
+        if pd.api.types.is_numeric_dtype(y_series):
+            y_vals = y_series.astype(float).tolist()[:5000]
+        else:
+            y_vals = pd.factorize(y_series)[0].tolist()[:5000]
         task_cat = _infer_task_category(y_vals, target)
         return {
             "columns": all_cols,
             "numeric_columns": numeric,
+            "target_columns": all_cols,
             "row_count": len(X),
             "sample_rows": sample,
             "suggested_target": target,
@@ -459,28 +460,32 @@ def preview_dataset(
 
     if source == "csv_url":
         import httpx
+        import pandas as pd
 
         resp = httpx.get(dataset_id, follow_redirects=True, timeout=60)
         resp.raise_for_status()
-        reader = csv.DictReader(io.StringIO(resp.text))
-        all_rows = list(reader)
-        if not all_rows:
+        df = pd.read_csv(io.StringIO(resp.text))
+        if df.empty:
             raise ValueError("CSV is empty")
-        all_cols = list(all_rows[0].keys())
-        numeric = _numeric_columns(all_rows)
-        suggested_target = numeric[-1] if numeric else all_cols[-1]
-        y_vals = []
-        for r in all_rows[:5000]:
-            try:
-                y_vals.append(float(r[suggested_target]))
-            except (ValueError, TypeError):
-                pass
-        task_cat = _infer_task_category(y_vals, suggested_target) if y_vals else "regression"
-        sample = all_rows[:5]
+        df.columns = [str(c).strip() for c in df.columns]
+        all_cols = list(df.columns)
+        numeric = list(df.select_dtypes(include=["number"]).columns)
+        suggested_target = str(all_cols[-1])
+        y_series = df[suggested_target].dropna()
+        if len(y_series):
+            if pd.api.types.is_numeric_dtype(y_series):
+                y_vals = y_series.astype(float).tolist()[:5000]
+            else:
+                y_vals = pd.factorize(y_series)[0].tolist()[:5000]
+            task_cat = _infer_task_category(y_vals, suggested_target)
+        else:
+            task_cat = "regression"
+        sample = df.head(5).to_dict("records")
         return {
             "columns": all_cols,
             "numeric_columns": numeric,
-            "row_count": len(all_rows),
+            "target_columns": all_cols,
+            "row_count": len(df),
             "sample_rows": sample,
             "suggested_target": suggested_target,
             "suggested_task_category": task_cat,

--- a/frontend/public_page/index.html
+++ b/frontend/public_page/index.html
@@ -1212,12 +1212,14 @@
         _datasetMeta = data;
 
         document.getElementById('dsPreviewTitle').textContent = data.display_name || 'Dataset';
+        const colCount = (data.columns && data.columns.length) || (data.target_columns && data.target_columns.length) || 0;
         document.getElementById('dsPreviewInfo').textContent =
-          `${data.row_count.toLocaleString()} rows · ${data.numeric_columns.length} numeric columns`;
+          `${data.row_count.toLocaleString()} rows · ${colCount} columns`;
 
+        const targetChoices = data.target_columns || data.columns || data.numeric_columns || [];
         const sel = document.getElementById('dsTarget');
         sel.innerHTML = '';
-        data.numeric_columns.forEach(c => {
+        targetChoices.forEach(c => {
           const opt = document.createElement('option');
           opt.value = c; opt.textContent = c;
           if (c === data.suggested_target) opt.selected = true;


### PR DESCRIPTION
Normalizes OpenML default targets, exposes `target_columns` for the submit UI, loads CSV URLs with pandas + categorical encoding (aligned with OpenML). Adds `/datasets` to public API prefixes.

**Deploy:** merge then Render deploy; sync dcn-worker `datasets.py` + ML handler from latest.

Made with [Cursor](https://cursor.com)