### PR TITLE
feat: requeue failed tasks with cooldown (cross-worker retry)

### DIFF
--- a/backend/apis/workers.py
+++ b/backend/apis/workers.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException
 from database import get_pool
 from schemas import TaskClaim, TaskComplete, TaskFail, WorkerHeartbeat, WorkerRegister, CacheLookup, CacheStore
 from aggregator import aggregate_job
+from config import MAX_TASK_FAILURE_RETRIES, TASK_FAILURE_RETRY_DELAY_SECONDS
 
 router = APIRouter()
 
@@ -44,11 +45,12 @@ async def claim_task(body: TaskClaim) -> dict:
             task = await conn.fetchrow(
                 """
                 UPDATE job_tasks
-                SET status = 'running', worker_node_id = $1, started_at = NOW()
+                SET status = 'running', worker_node_id = $1, started_at = NOW(), claim_after = NULL
                 WHERE id = (
                     SELECT jt.id FROM job_tasks jt
                     JOIN jobs j ON j.id = jt.job_id
                     WHERE jt.status = 'queued'
+                      AND (jt.claim_after IS NULL OR jt.claim_after <= NOW())
                       AND j.task_type = ANY($2)
                       AND COALESCE((jt.task_payload->>'min_tier')::int, 1) <= $3
                     ORDER BY (COALESCE((jt.task_payload->>'min_tier')::int, 1) = $3) DESC,
@@ -68,11 +70,12 @@ async def claim_task(body: TaskClaim) -> dict:
             task = await conn.fetchrow(
                 """
                 UPDATE job_tasks
-                SET status = 'running', worker_node_id = $1, started_at = NOW()
+                SET status = 'running', worker_node_id = $1, started_at = NOW(), claim_after = NULL
                 WHERE id = (
                     SELECT jt.id FROM job_tasks jt
                     JOIN jobs j ON j.id = jt.job_id
                     WHERE jt.status = 'queued'
+                      AND (jt.claim_after IS NULL OR jt.claim_after <= NOW())
                       AND COALESCE((jt.task_payload->>'min_tier')::int, 1) <= $2
                     ORDER BY (COALESCE((jt.task_payload->>'min_tier')::int, 1) = $2) DESC,
                              j.priority DESC,
@@ -253,90 +256,132 @@ async def validate_task(task_id: str) -> dict:
 
 @router.post("/tasks/{task_id}/fail")
 async def fail_task(task_id: str, body: TaskFail = TaskFail()) -> dict:
-    """Mark a task as failed when processing errors out. Optional worker error text is logged."""
+    """Record task failure: requeue with cooldown so other workers can claim, or fail permanently after max retries."""
     pool = await get_pool()
     async with pool.acquire() as conn:
-        task = await conn.fetchrow(
-            "SELECT * FROM job_tasks WHERE id = $1", task_id
-        )
-        if not task:
-            raise HTTPException(status_code=404, detail="Task not found")
+        async with conn.transaction():
+            task = await conn.fetchrow(
+                "SELECT * FROM job_tasks WHERE id = $1 FOR UPDATE", task_id
+            )
+            if not task:
+                raise HTTPException(status_code=404, detail="Task not found")
+            if task["status"] != "running":
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Task is '{task['status']}', expected 'running'",
+                )
 
-        updated = await conn.fetchrow(
-            "UPDATE job_tasks SET status = 'failed' WHERE id = $1 RETURNING *",
-            task_id,
-        )
+            prev_failures = int(task["failure_count"] or 0)
+            new_failures = prev_failures + 1
+            requeue = new_failures < MAX_TASK_FAILURE_RETRIES
 
-        # Set worker back to online
-        if task["worker_node_id"]:
-            await conn.execute(
-                "UPDATE worker_nodes SET status = 'online' WHERE id = $1",
-                task["worker_node_id"],
+            err = (body.error or "").strip()
+            if len(err) > 4000:
+                err = err[:4000] + "…"
+            msg = (
+                f"Task {task_id} failed: {err}"
+                if err
+                else f"Task {task_id} failed during processing"
             )
 
-        err = (body.error or "").strip()
-        if len(err) > 4000:
-            err = err[:4000] + "…"
-        msg = (
-            f"Task {task_id} failed: {err}"
-            if err
-            else f"Task {task_id} failed during processing"
-        )
-
-        # Log failure event (visible in /ops event feed)
-        await conn.execute(
-            """
-            INSERT INTO job_events (job_id, event_type, message)
-            VALUES ($1, 'task_failed', $2)
-            """,
-            task["job_id"],
-            msg,
-        )
-
-        # Store on task_results so job detail table can show the reason (not just "failed")
-        await conn.execute("DELETE FROM task_results WHERE task_id = $1", task_id)
-        await conn.execute(
-            """
-            INSERT INTO task_results (task_id, worker_node_id, result_text, result_payload, status)
-            VALUES ($1, $2, $3, '{}'::jsonb, 'failed')
-            """,
-            task_id,
-            task["worker_node_id"],
-            msg,
-        )
-
-        # If all tasks are terminal (submitted or failed), mark job as failed
-        counts = await conn.fetchrow(
-            """
-            SELECT
-                COUNT(*) AS total,
-                COUNT(*) FILTER (WHERE status IN ('submitted', 'failed')) AS done
-            FROM job_tasks WHERE job_id = $1
-            """,
-            task["job_id"],
-        )
-        if counts["done"] >= counts["total"]:
-            # Check if any submitted — if so, aggregation will handle it; otherwise job failed
-            submitted = await conn.fetchval(
-                "SELECT COUNT(*) FROM job_tasks WHERE job_id = $1 AND status = 'submitted'",
-                task["job_id"],
-            )
-            if submitted == 0:
+            if requeue:
+                updated = await conn.fetchrow(
+                    """
+                    UPDATE job_tasks
+                    SET status = 'queued',
+                        worker_node_id = NULL,
+                        started_at = NULL,
+                        completed_at = NULL,
+                        failure_count = $2,
+                        claim_after = NOW() + $3 * INTERVAL '1 second'
+                    WHERE id = $1
+                    RETURNING *
+                    """,
+                    task_id,
+                    new_failures,
+                    TASK_FAILURE_RETRY_DELAY_SECONDS,
+                )
+                await conn.execute("DELETE FROM task_results WHERE task_id = $1", task_id)
                 await conn.execute(
-                    "UPDATE jobs SET status = 'failed', updated_at = NOW() WHERE id = $1",
+                    """
+                    INSERT INTO job_events (job_id, event_type, message)
+                    VALUES ($1, 'task_retry_scheduled', $2)
+                    """,
                     task["job_id"],
+                    f"{msg} — requeued; claimable after {TASK_FAILURE_RETRY_DELAY_SECONDS}s "
+                    f"(attempt {new_failures}/{MAX_TASK_FAILURE_RETRIES})",
+                )
+            else:
+                updated = await conn.fetchrow(
+                    """
+                    UPDATE job_tasks SET status = 'failed', failure_count = $2 WHERE id = $1 RETURNING *
+                    """,
+                    task_id,
+                    new_failures,
                 )
                 await conn.execute(
                     """
                     INSERT INTO job_events (job_id, event_type, message)
-                    VALUES ($1, 'job_failed', 'All tasks failed')
+                    VALUES ($1, 'task_failed', $2)
+                    """,
+                    task["job_id"],
+                    msg,
+                )
+                await conn.execute("DELETE FROM task_results WHERE task_id = $1", task_id)
+                await conn.execute(
+                    """
+                    INSERT INTO task_results (task_id, worker_node_id, result_text, result_payload, status)
+                    VALUES ($1, $2, $3, '{}'::jsonb, 'failed')
+                    """,
+                    task_id,
+                    task["worker_node_id"],
+                    msg,
+                )
+
+            # Set worker back to online
+            if task["worker_node_id"]:
+                await conn.execute(
+                    "UPDATE worker_nodes SET status = 'online' WHERE id = $1",
+                    task["worker_node_id"],
+                )
+
+            if not requeue:
+                counts = await conn.fetchrow(
+                    """
+                    SELECT
+                        COUNT(*) AS total,
+                        COUNT(*) FILTER (WHERE status IN ('submitted', 'failed')) AS done
+                    FROM job_tasks WHERE job_id = $1
                     """,
                     task["job_id"],
                 )
-            else:
-                await aggregate_job(conn, task["job_id"])
+                if counts["done"] >= counts["total"]:
+                    submitted = await conn.fetchval(
+                        "SELECT COUNT(*) FROM job_tasks WHERE job_id = $1 AND status = 'submitted'",
+                        task["job_id"],
+                    )
+                    if submitted == 0:
+                        await conn.execute(
+                            "UPDATE jobs SET status = 'failed', updated_at = NOW() WHERE id = $1",
+                            task["job_id"],
+                        )
+                        await conn.execute(
+                            """
+                            INSERT INTO job_events (job_id, event_type, message)
+                            VALUES ($1, 'job_failed', 'All tasks failed')
+                            """,
+                            task["job_id"],
+                        )
+                    else:
+                        await aggregate_job(conn, task["job_id"])
 
-    return {"failed": True, "task": dict(updated)}
+    return {
+        "failed": not requeue,
+        "requeued": requeue,
+        "task": dict(updated),
+        "failure_count": new_failures,
+        "retry_delay_seconds": TASK_FAILURE_RETRY_DELAY_SECONDS if requeue else None,
+    }
 
 
 @router.post("/workers/heartbeat")

--- a/backend/config.py
+++ b/backend/config.py
@@ -16,6 +16,10 @@ RETRY_BACKOFF_SECONDS: list[int] = [5, 15, 30]
 RATE_LIMIT_BACKOFF_MULTIPLIER: int = 2
 WORKER_POLL_INTERVAL_SECONDS: int = 5
 
+# ── Task failure → requeue (another worker can claim after delay) ──
+TASK_FAILURE_RETRY_DELAY_SECONDS: int = 60
+MAX_TASK_FAILURE_RETRIES: int = 5
+
 # ── Auth ─────────────────────────────────────────────────────
 SESSION_MAX_AGE_SECONDS: int = 86400  # 24 hours
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -51,7 +51,10 @@ async def _maintenance_loop():
                 reaped = await conn.fetch(
                     """
                     UPDATE job_tasks
-                    SET status = 'queued', worker_node_id = NULL, started_at = NULL
+                    SET status = 'queued',
+                        worker_node_id = NULL,
+                        started_at = NULL,
+                        claim_after = NULL
                     WHERE status = 'running'
                       AND started_at IS NOT NULL
                       AND started_at < NOW() - INTERVAL '{} minutes'
@@ -154,6 +157,30 @@ async def _migrate_jobs_user_fk_to_dcn_users(conn) -> None:
     logger.info("Added jobs.user_id foreign key to dcn_users")
 
 
+async def _migrate_job_tasks_retry_columns(conn) -> None:
+    """Add claim_after + failure_count for requeue-on-fail with cooldown."""
+    exists = await conn.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'job_tasks'
+        )
+        """
+    )
+    if not exists:
+        return
+    await conn.execute(
+        "ALTER TABLE job_tasks ADD COLUMN IF NOT EXISTS claim_after TIMESTAMPTZ"
+    )
+    await conn.execute(
+        """
+        ALTER TABLE job_tasks
+        ADD COLUMN IF NOT EXISTS failure_count INTEGER NOT NULL DEFAULT 0
+        """
+    )
+    logger.info("Ensured job_tasks.claim_after and job_tasks.failure_count exist")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Start up: connect to DB, create static cache table, + start maintenance. Shut down: clean up."""
@@ -197,6 +224,11 @@ async def lifespan(app: FastAPI):
             await _migrate_jobs_user_fk_to_dcn_users(conn)
         except Exception as e:
             logger.error("jobs.user_id FK migration failed: %s", e, exc_info=True)
+            raise
+        try:
+            await _migrate_job_tasks_retry_columns(conn)
+        except Exception as e:
+            logger.error("job_tasks retry columns migration failed: %s", e, exc_info=True)
             raise
     maintenance_task = asyncio.create_task(_maintenance_loop())
     yield

--- a/schema.sql
+++ b/schema.sql
@@ -37,7 +37,9 @@ CREATE TABLE IF NOT EXISTS job_tasks (
     started_at          TIMESTAMPTZ,
     completed_at        TIMESTAMPTZ,
     created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    worker_node_id      UUID
+    worker_node_id      UUID,
+    claim_after         TIMESTAMPTZ,
+    failure_count       INTEGER NOT NULL DEFAULT 0
 );
 
 -- ─── Job Events (event log) ─────────────────────────────


### PR DESCRIPTION
## Summary
Implements resilient task handling: when a worker reports failure, the task returns to the queue after a short cooldown so **other workers can claim it first**, instead of staying bound to a bad machine.

## Changes
- `POST /tasks/{id}/fail`: increments `failure_count`; requeues (`status=queued`, `claim_after`) until `MAX_TASK_FAILURE_RETRIES`; then permanent `failed`.
- `POST /tasks/claim`: only claims `queued` rows with `claim_after IS NULL OR claim_after <= NOW()`.
- DB: `job_tasks.claim_after`, `job_tasks.failure_count` + startup migration.
- Config: `TASK_FAILURE_RETRY_DELAY_SECONDS` (60), `MAX_TASK_FAILURE_RETRIES` (5).

## Response shape
`/fail` returns `requeued`, `failure_count`, `retry_delay_seconds`, `failed` (true only for terminal failure).

Made with [Cursor](https://cursor.com)