### PR TITLE
feat: admin Users page (directory, roles, job & session audit)

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -146,13 +146,94 @@ async def list_users() -> list[dict]:
         ]
 
 
+async def fetch_user_jobs_summary(user_id: str, limit: int = 100) -> list[dict]:
+    """Recent jobs for a user (admin/CEO)."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT id, title, task_type, status, created_at, updated_at
+            FROM jobs
+            WHERE user_id = $1::uuid
+            ORDER BY created_at DESC
+            LIMIT $2
+            """,
+            user_id,
+            limit,
+        )
+    return [
+        {
+            "id": str(r["id"]),
+            "title": r["title"],
+            "task_type": r["task_type"],
+            "status": r["status"],
+            "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+            "updated_at": r["updated_at"].isoformat() if r["updated_at"] else None,
+        }
+        for r in rows
+    ]
+
+
+async def fetch_user_job_stats(user_id: str) -> dict:
+    """Aggregate job counts by status for a user."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT status, COUNT(*)::int AS n
+            FROM jobs
+            WHERE user_id = $1::uuid
+            GROUP BY status
+            """,
+            user_id,
+        )
+    counts = {r["status"]: r["n"] for r in rows}
+    total = sum(counts.values())
+    return {"total_jobs": total, "by_status": counts}
+
+
+async def fetch_user_session_audit(user_id: str) -> dict:
+    """OAuth sessions are created at login — use as sign-in audit trail (no tokens returned)."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        n = await conn.fetchval(
+            "SELECT COUNT(*) FROM sessions WHERE user_id = $1::uuid",
+            user_id,
+        )
+        recent = await conn.fetch(
+            """
+            SELECT created_at
+            FROM sessions
+            WHERE user_id = $1::uuid
+            ORDER BY created_at DESC
+            LIMIT 25
+            """,
+            user_id,
+        )
+    return {
+        "active_session_count": int(n or 0),
+        "recent_logins": [r["created_at"].isoformat() for r in recent],
+    }
+
+
 # Pages that require admin (or ceo) role
-ADMIN_PAGES = {"/ops", "/results", "/worker-logs"}
+ADMIN_PAGES = {"/ops", "/results", "/worker-logs", "/admin/users"}
 # API routes that require admin (or ceo) role
 ADMIN_API_PREFIXES = ["/monitor/"]
 # Pages that require any authenticated user (non-admin)
 AUTH_REQUIRED_PAGES = {"/submit"}
 # Prefixes that don't need auth
+# OAuth callbacks must be reachable without a session; do not use blanket "/auth/" or /auth/users would be public.
 PUBLIC_PREFIXES = [
-    "/login", "/health", "/workers/", "/tasks/", "/jobs", "/auth/", "/stats", "/my-jobs", "/datasets",
+    "/login",
+    "/health",
+    "/workers/",
+    "/tasks/",
+    "/jobs",
+    "/auth/google",
+    "/auth/github",
+    "/auth/logout",
+    "/stats",
+    "/my-jobs",
+    "/datasets",
 ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,9 @@ import os
 import asyncio
 import httpx
 from urllib.parse import urlencode
-from fastapi import FastAPI, Request
+from uuid import UUID
+
+from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from contextlib import asynccontextmanager
@@ -14,6 +16,7 @@ from apis.workers import router as workers_router
 from auth import (
     find_or_create_oauth_user, create_session, get_session, destroy_session,
     update_user_role, list_users,
+    fetch_user_jobs_summary, fetch_user_job_stats, fetch_user_session_audit,
     SESSION_COOKIE, ADMIN_PAGES, ADMIN_API_PREFIXES, AUTH_REQUIRED_PAGES, PUBLIC_PREFIXES, ELEVATED_ROLES,
 )
 from config import (
@@ -37,6 +40,7 @@ LOGIN_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "login")
 MYJOBS_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "my-jobs")
 ERROR_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "error")
 WORKER_LOGS_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "worker-logs")
+ADMIN_USERS_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "admin-users")
 
 
 async def _maintenance_loop():
@@ -280,6 +284,12 @@ async def auth_middleware(request: Request, call_next):
         if not user or user["role"] not in ELEVATED_ROLES:
             return JSONResponse({"detail": "Admin access required"}, status_code=401)
 
+    # User directory & audit APIs (not /auth/me, /auth/logout, OAuth callbacks)
+    if path.startswith("/auth/users"):
+        user = await get_session(request)
+        if not user or user["role"] not in ELEVATED_ROLES:
+            return JSONResponse({"detail": "Admin or CEO access required"}, status_code=401)
+
     return await call_next(request)
 
 
@@ -446,21 +456,37 @@ async def do_logout(request: Request):
     return response
 
 
-# ── CEO user management ──────────────────────────────────────
+# ── User management (admin + CEO) / role changes (CEO only) ──
 @app.get("/auth/users")
 async def get_users(request: Request):
     user = await get_session(request)
-    if not user or user["role"] != "ceo":
-        return JSONResponse({"detail": "CEO access required"}, status_code=403)
+    if not user or user["role"] not in ELEVATED_ROLES:
+        return JSONResponse({"detail": "Admin or CEO access required"}, status_code=403)
     users = await list_users()
     return users
+
+
+@app.get("/auth/users/{user_id}/audit")
+async def get_user_audit(request: Request, user_id: str):
+    """Jobs summary, recent jobs, and session/login timestamps for a user."""
+    user = await get_session(request)
+    if not user or user["role"] not in ELEVATED_ROLES:
+        return JSONResponse({"detail": "Admin or CEO access required"}, status_code=403)
+    try:
+        UUID(user_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Invalid user id")
+    job_stats = await fetch_user_job_stats(user_id)
+    jobs = await fetch_user_jobs_summary(user_id, limit=80)
+    sessions = await fetch_user_session_audit(user_id)
+    return {"job_stats": job_stats, "jobs": jobs, "sessions": sessions}
 
 
 @app.post("/auth/role")
 async def change_role(request: Request):
     user = await get_session(request)
     if not user or user["role"] != "ceo":
-        return JSONResponse({"detail": "CEO access required"}, status_code=403)
+        return JSONResponse({"detail": "CEO access required — only CEO can change roles"}, status_code=403)
     try:
         body = await request.json()
     except Exception:
@@ -515,6 +541,14 @@ async def serve_my_jobs():
 @app.get("/worker-logs")
 async def serve_worker_logs():
     response = FileResponse(os.path.join(WORKER_LOGS_DIR, "index.html"))
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    return response
+
+
+@app.get("/admin/users")
+async def serve_admin_users():
+    response = FileResponse(os.path.join(ADMIN_USERS_DIR, "index.html"))
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
     response.headers["Pragma"] = "no-cache"
     return response

--- a/frontend/admin-users/index.html
+++ b/frontend/admin-users/index.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DCN — Users &amp; access</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#14161e;--surface:rgba(255,255,255,0.06);--border:rgba(255,255,255,0.10);
+  --text:#e8e8ec;--muted:#b4b4bc;--dim:#8a8a96;--accent:#7c3aed;--accent3:#3b82f6;
+  --green:#22c55e;--red:#ef4444;
+}
+body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;-webkit-font-smoothing:antialiased}
+
+.app-layout{display:flex;min-height:100vh}
+.sidebar{width:240px;min-width:240px;background:rgba(16,18,26,0.55);backdrop-filter:blur(24px);border-right:1px solid rgba(255,255,255,0.06);display:flex;flex-direction:column;padding:24px 0;position:fixed;top:0;left:0;bottom:0;z-index:10}
+.sidebar-logo{font-weight:800;font-size:20px;background:linear-gradient(135deg,#a78bfa,#60a5fa);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-decoration:none;padding:0 24px;margin-bottom:8px;display:block}
+.sidebar-role{font-size:0.68rem;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:#7c3aed;padding:0 24px;margin-bottom:24px}
+.sidebar-nav{display:flex;flex-direction:column;gap:2px;flex:1;padding:0 12px}
+.sidebar-nav a{display:flex;align-items:center;gap:10px;color:rgba(255,255,255,0.45);text-decoration:none;font-size:0.88rem;font-weight:500;padding:10px 14px;border-radius:10px;transition:all 0.15s}
+.sidebar-nav a:hover{color:#fff;background:rgba(255,255,255,0.04)}
+.sidebar-nav a.active{color:#fff;background:linear-gradient(135deg,rgba(124,58,237,0.15),rgba(59,130,246,0.10));border:1px solid rgba(124,58,237,0.2)}
+.sidebar-nav a svg{width:18px;height:18px;flex-shrink:0}
+.sidebar-bottom{padding:16px 12px 0;border-top:1px solid rgba(255,255,255,0.06);margin-top:auto}
+.sidebar-user{padding:10px 14px;display:flex;align-items:center;gap:10px;margin-bottom:4px}
+.sidebar-user-avatar{width:32px;height:32px;border-radius:8px;background:linear-gradient(135deg,#7c3aed,#3b82f6);display:flex;align-items:center;justify-content:center;font-size:0.82rem;font-weight:700;color:#fff;flex-shrink:0;overflow:hidden}
+.sidebar-user-name{font-size:0.85rem;font-weight:600;color:#fff}
+.sidebar-user-role{font-size:0.7rem;color:rgba(255,255,255,0.35);text-transform:capitalize}
+.sidebar-signout{display:flex;align-items:center;gap:10px;color:rgba(255,255,255,0.35);text-decoration:none;font-size:0.82rem;font-weight:500;padding:10px 14px;border-radius:10px}
+.sidebar-signout:hover{color:#ef4444;background:rgba(239,68,68,0.06)}
+.sidebar-signout svg{width:16px;height:16px}
+
+.main-content{margin-left:240px;flex:1;min-width:0;padding:32px 40px 60px;max-width:1200px}
+.page-title{font-size:1.5rem;font-weight:800;letter-spacing:-0.5px;margin-bottom:4px}
+.page-subtitle{font-size:0.85rem;color:var(--dim);margin-bottom:24px;max-width:720px;line-height:1.5}
+
+.hint{font-size:0.78rem;color:var(--dim);background:rgba(124,58,237,0.08);border:1px solid rgba(124,58,237,0.2);border-radius:10px;padding:12px 14px;margin-bottom:24px}
+.hint strong{color:var(--muted)}
+
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:24px;align-items:start}
+@media(max-width:1024px){.grid2{grid-template-columns:1fr}}
+
+.panel{background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.07);border-radius:16px;overflow:hidden}
+.panel-h{padding:14px 18px;font-size:0.72rem;font-weight:700;text-transform:uppercase;letter-spacing:0.8px;color:var(--dim);border-bottom:1px solid rgba(255,255,255,0.06)}
+.panel-b{padding:0;max-height:420px;overflow:auto}
+
+table{width:100%;border-collapse:collapse;font-size:0.82rem}
+th{text-align:left;padding:10px 14px;background:rgba(0,0,0,0.2);color:var(--dim);font-weight:600;font-size:0.68rem;text-transform:uppercase;letter-spacing:0.4px}
+td{padding:10px 14px;border-bottom:1px solid rgba(255,255,255,0.04);vertical-align:top}
+tr.user-row{cursor:pointer;transition:background .12s}
+tr.user-row:hover{background:rgba(124,58,237,0.06)}
+tr.user-row.selected{background:rgba(124,58,237,0.12)}
+.badge-role{display:inline-block;padding:2px 8px;border-radius:6px;font-size:0.68rem;font-weight:600;text-transform:uppercase}
+.br-ceo{background:rgba(234,179,8,0.15);color:#facc15}
+.br-admin{background:rgba(59,130,246,0.15);color:#60a5fa}
+.br-customer{background:rgba(255,255,255,0.08);color:var(--muted)}
+
+.detail{padding:20px 22px}
+.detail h3{font-size:0.95rem;margin-bottom:12px}
+.meta-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:10px;margin-bottom:16px}
+.meta-item{background:rgba(0,0,0,0.15);border-radius:10px;padding:10px 12px}
+.meta-item span{display:block;font-size:0.65rem;color:var(--dim);text-transform:uppercase;letter-spacing:0.3px;margin-bottom:4px}
+.meta-item strong{font-size:0.95rem}
+
+.role-row{display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:16px}
+.role-row select{padding:8px 12px;border-radius:8px;background:rgba(0,0,0,0.25);border:1px solid rgba(255,255,255,0.12);color:#fff;font-size:0.85rem}
+.role-row button{padding:8px 16px;border-radius:8px;border:none;background:linear-gradient(135deg,var(--accent),var(--accent3));color:#fff;font-weight:600;font-size:0.82rem;cursor:pointer}
+.role-row button:disabled{opacity:0.4;cursor:not-allowed}
+.note{font-size:0.75rem;color:var(--dim);margin-top:8px}
+
+.jobs-mini{margin-top:8px}
+.jobs-mini table{font-size:0.78rem}
+.jobs-mini th,.jobs-mini td{padding:8px 10px}
+.badge-job{display:inline-block;padding:2px 6px;border-radius:4px;font-size:0.65rem;font-weight:600;text-transform:uppercase}
+.bj-completed{color:#4ade80}.bj-running{color:#60a5fa}.bj-queued{color:#facc15}.bj-failed{color:#f87171}
+
+.logins{font-size:0.78rem;color:var(--muted);font-family:ui-monospace,monospace;line-height:1.6;max-height:140px;overflow:auto}
+.err{color:#f87171;font-size:0.85rem;margin-top:12px}
+
+@media(max-width:768px){.sidebar{display:none}.main-content{margin-left:0}}
+</style>
+</head>
+<body>
+<div class="app-layout">
+<aside class="sidebar">
+  <a href="/" class="sidebar-logo">DCN</a>
+  <div class="sidebar-role" id="sidebarRole">Admin</div>
+  <nav class="sidebar-nav">
+    <a href="/submit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>Submit Job</a>
+    <a href="/ops"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</a>
+    <a href="/results"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14,2 14,8 20,8"/></svg>Results</a>
+    <a href="/worker-logs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>Worker Logs</a>
+    <a href="/admin/users" class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>Users</a>
+    <a href="/my-jobs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/></svg>My Jobs</a>
+  </nav>
+  <div class="sidebar-bottom">
+    <div class="sidebar-user">
+      <div class="sidebar-user-avatar" id="userAvatar">?</div>
+      <div>
+        <div class="sidebar-user-name" id="userName">—</div>
+        <div class="sidebar-user-role" id="userRoleLabel">—</div>
+      </div>
+    </div>
+    <a href="/auth/logout" class="sidebar-signout"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16,17 21,12 16,7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>Sign Out</a>
+  </div>
+</aside>
+
+<div class="main-content">
+  <h1 class="page-title">Users &amp; access</h1>
+  <p class="page-subtitle">Directory of sign-ins (Google / GitHub), roles, and job history. CEOs can assign <strong>admin</strong> or <strong>customer</strong>. The CEO account is controlled by the <code>CEO_EMAIL</code> environment variable.</p>
+
+  <div class="hint" id="ceoHint" style="display:none">
+    <strong>CEO</strong> — Use the role control below to promote or demote users. Admins can view this page but cannot change roles.
+  </div>
+  <div class="hint" id="adminHint" style="display:none">
+    <strong>Admin</strong> — Read-only directory. Ask a CEO to change roles.
+  </div>
+
+  <div id="loadErr" class="err" style="display:none"></div>
+
+  <div class="grid2">
+    <div class="panel">
+      <div class="panel-h">Accounts</div>
+      <div class="panel-b">
+        <table>
+          <thead><tr><th>User</th><th>Provider</th><th>Role</th><th>Joined</th></tr></thead>
+          <tbody id="userTbody"></tbody>
+        </table>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="panel-h">Selected user</div>
+      <div class="detail" id="detailPanel">
+        <p style="color:var(--dim);font-size:0.88rem">Select a row to see email, job stats, recent jobs, and sign-in activity (session starts).</p>
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+
+<script>
+const API = window.location.origin;
+let me = null;
+let users = [];
+let selectedId = null;
+
+function roleClass(r) {
+  if (r === 'ceo') return 'badge-role br-ceo';
+  if (r === 'admin') return 'badge-role br-admin';
+  return 'badge-role br-customer';
+}
+
+async function init() {
+  const r = await fetch('/auth/me', { credentials: 'include' });
+  if (!r.ok) { window.location.href = '/login'; return; }
+  me = await r.json();
+  if (me.role !== 'admin' && me.role !== 'ceo') {
+    window.location.href = '/submit';
+    return;
+  }
+  document.getElementById('userName').textContent = me.name || me.email;
+  document.getElementById('userRoleLabel').textContent = me.role;
+  const av = document.getElementById('userAvatar');
+  if (me.avatar_url) av.innerHTML = '<img src="'+me.avatar_url+'" style="width:100%;height:100%;border-radius:8px;object-fit:cover">';
+  else av.textContent = (me.name || me.email).charAt(0).toUpperCase();
+  document.getElementById('sidebarRole').textContent = me.role === 'ceo' ? 'CEO Panel' : 'Admin Panel';
+  document.getElementById('ceoHint').style.display = me.role === 'ceo' ? 'block' : 'none';
+  document.getElementById('adminHint').style.display = me.role === 'admin' ? 'block' : 'none';
+
+  const ur = await fetch('/auth/users', { credentials: 'include' });
+  if (!ur.ok) {
+    document.getElementById('loadErr').style.display = 'block';
+    document.getElementById('loadErr').textContent = await ur.text();
+    return;
+  }
+  users = await ur.json();
+  renderTable();
+}
+
+function renderTable() {
+  const tb = document.getElementById('userTbody');
+  tb.innerHTML = users.map(u => `
+    <tr class="user-row ${selectedId === u.id ? 'selected' : ''}" data-id="${u.id}">
+      <td><strong>${escapeHtml(u.email)}</strong><br><span style="color:var(--dim);font-size:0.75rem">${escapeHtml(u.name || '—')}</span></td>
+      <td>${escapeHtml(u.provider)}</td>
+      <td><span class="${roleClass(u.role)}">${escapeHtml(u.role)}</span></td>
+      <td style="color:var(--dim);font-size:0.78rem">${fmtDate(u.created_at)}</td>
+    </tr>
+  `).join('');
+  tb.querySelectorAll('.user-row').forEach(row => {
+    row.addEventListener('click', () => selectUser(row.dataset.id));
+  });
+}
+
+function escapeHtml(s) {
+  if (!s) return '';
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  try { return new Date(iso).toLocaleString(); } catch { return iso; }
+}
+
+function statusClass(s) {
+  const x = (s || '').toLowerCase();
+  if (x === 'completed') return 'bj-completed';
+  if (x === 'running') return 'bj-running';
+  if (x === 'queued') return 'bj-queued';
+  if (x === 'failed') return 'bj-failed';
+  return '';
+}
+
+async function selectUser(id) {
+  selectedId = id;
+  renderTable();
+  const u = users.find(x => x.id === id);
+  const panel = document.getElementById('detailPanel');
+  panel.innerHTML = '<p style="color:var(--dim)">Loading…</p>';
+
+  const ar = await fetch('/auth/users/' + encodeURIComponent(id) + '/audit', { credentials: 'include' });
+  if (!ar.ok) {
+    panel.innerHTML = '<p class="err">Could not load audit data.</p>';
+    return;
+  }
+  const audit = await ar.json();
+  const stats = audit.job_stats || {};
+  const by = stats.by_status || {};
+  const jobs = audit.jobs || [];
+  const sess = audit.sessions || {};
+
+  const canEditRole = me.role === 'ceo' && u.role !== 'ceo' && u.id !== me.id;
+  const roleControl = canEditRole ? `
+    <div class="role-row">
+      <label for="roleSel" style="font-size:0.82rem;color:var(--muted)">Role</label>
+      <select id="roleSel">
+        <option value="customer" ${u.role === 'customer' ? 'selected' : ''}>customer</option>
+        <option value="admin" ${u.role === 'admin' ? 'selected' : ''}>admin</option>
+      </select>
+      <button type="button" id="saveRoleBtn">Save role</button>
+    </div>
+    <p class="note">Cannot change CEO or your own account here.</p>
+  ` : `<p style="font-size:0.82rem;color:var(--dim)">Current role: <strong>${escapeHtml(u.role)}</strong>${u.role === 'ceo' ? ' (set via CEO_EMAIL)' : ''}</p>`;
+
+  panel.innerHTML = `
+    <h3>${escapeHtml(u.email)}</h3>
+    ${roleControl}
+    <div class="meta-grid">
+      <div class="meta-item"><span>Total jobs</span><strong>${stats.total_jobs ?? 0}</strong></div>
+      <div class="meta-item"><span>Active sessions</span><strong>${sess.active_session_count ?? 0}</strong></div>
+    </div>
+    <p style="font-size:0.72rem;color:var(--dim);text-transform:uppercase;letter-spacing:0.5px;margin-top:8px">Jobs by status</p>
+    <p style="font-size:0.85rem;color:var(--muted);margin-bottom:12px">${Object.keys(by).length ? Object.entries(by).map(([k,v]) => k + ': ' + v).join(' · ') : 'None yet'}</p>
+    <p style="font-size:0.72rem;color:var(--dim);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px">Recent jobs</p>
+    <div class="jobs-mini panel-b" style="max-height:200px;border:1px solid rgba(255,255,255,0.06);border-radius:10px">
+      <table><thead><tr><th>Title</th><th>Type</th><th>Status</th><th>Created</th></tr></thead><tbody>
+      ${jobs.length ? jobs.map(j => `<tr><td>${escapeHtml(j.title)}</td><td>${escapeHtml(j.task_type)}</td><td><span class="badge-job ${statusClass(j.status)}">${escapeHtml(j.status)}</span></td><td style="color:var(--dim);font-size:0.72rem">${fmtDate(j.created_at)}</td></tr>`).join('') : '<tr><td colspan="4" style="color:var(--dim)">No jobs</td></tr>'}
+      </tbody></table>
+    </div>
+    <p style="font-size:0.72rem;color:var(--dim);text-transform:uppercase;letter-spacing:0.5px;margin:16px 0 6px">Recent sign-ins (session created)</p>
+    <div class="logins">${(sess.recent_logins || []).length ? (sess.recent_logins || []).map(t => escapeHtml(t)).join('<br>') : 'No session rows (user never logged in or DB empty)'}</div>
+    <p id="roleMsg" class="err" style="display:none;margin-top:12px"></p>
+  `;
+
+  const btn = document.getElementById('saveRoleBtn');
+  if (btn && canEditRole) {
+    btn.addEventListener('click', async () => {
+      const sel = document.getElementById('roleSel');
+      const msg = document.getElementById('roleMsg');
+      msg.style.display = 'none';
+      btn.disabled = true;
+      const pr = await fetch('/auth/role', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: id, role: sel.value }),
+      });
+      btn.disabled = false;
+      if (!pr.ok) {
+        msg.style.display = 'block';
+        msg.textContent = (await pr.json().catch(() => ({}))).detail || await pr.text();
+        return;
+      }
+      const ur = await fetch('/auth/users', { credentials: 'include' });
+      users = await ur.json();
+      renderTable();
+      selectUser(id);
+    });
+  }
+}
+
+init();
+</script>
+</body>
+</html>

--- a/frontend/monitor/index.html
+++ b/frontend/monitor/index.html
@@ -915,6 +915,10 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
         Worker Logs
       </a>
+      <a href="/admin/users">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>
+        Users
+      </a>
       <a href="/my-jobs">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/></svg>
         My Jobs

--- a/frontend/my-jobs/index.html
+++ b/frontend/my-jobs/index.html
@@ -180,6 +180,7 @@ fetch('/auth/me',{credentials:'include'}).then(r=>r.ok?r.json():null).then(u=>{
         <a href="/ops"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>Dashboard</a>
         <a href="/results"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14,2 14,8 20,8"/></svg>Results</a>
         <a href="/worker-logs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>Worker Logs</a>
+        <a href="/admin/users"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>Users</a>
         <a href="/my-jobs" class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/></svg>My Jobs</a>
       `;
     } else {

--- a/frontend/results/index.html
+++ b/frontend/results/index.html
@@ -187,6 +187,10 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
       Worker Logs
     </a>
+    <a href="/admin/users">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>
+      Users
+    </a>
     <a href="/my-jobs">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/></svg>
       My Jobs

--- a/frontend/worker-logs/index.html
+++ b/frontend/worker-logs/index.html
@@ -121,6 +121,10 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
       Worker Logs
     </a>
+    <a href="/admin/users">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/></svg>
+      Users
+    </a>
     <a href="/my-jobs">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/></svg>
       My Jobs


### PR DESCRIPTION
## Summary
- New **`/admin/users`** page for **admin** and **CEO**: user directory (email, provider, role, joined), detail panel with job stats, recent jobs, session-based sign-in times.
- **CEO** can assign **admin** / **customer** via existing `POST /auth/role`; admins get read-only directory.
- APIs: `GET /auth/users`, `GET /auth/users/{id}/audit`.
- **Security:** remove blanket `/auth/` from public prefixes; require elevated session for `/auth/users*` in middleware.
- Sidebar **Users** link on Dashboard, Results, Worker Logs, My Jobs.

Made with [Cursor](https://cursor.com)