### PR TITLE
feat: job exports, tier queue fallback, ML planner tuning

### DIFF
--- a/backend/aggregator.py
+++ b/backend/aggregator.py
@@ -94,39 +94,59 @@ def _concatenate_results(results: list) -> str:
     return "\n\n---\n\n".join(sections)
 
 
-def _aggregate_ml_experiment(results: list, job: dict) -> str:
+def parse_ml_experiments_from_task_rows(results: list) -> list[dict]:
     """
-    Custom aggregation for ml_experiment: parse JSON metrics from each
-    experiment result, rank them, and produce a structured comparison report.
-    Now includes CV scores, compute time breakdown, and more metrics.
+    Extract embedded ```json``` metrics dicts from each task result (same logic as aggregation).
+    Used by export and by _aggregate_ml_experiment.
     """
     import re
     import json as json_mod
 
     experiments = []
-
     for r in results:
         text = r["result_text"] or ""
-
-        # Extract the JSON block embedded in each result
-        json_match = re.search(r'```json\s*\n(\{.*?\})\s*\n```', text, re.DOTALL)
+        json_match = re.search(r"```json\s*\n(\{.*?\})\s*\n```", text, re.DOTALL)
         if json_match:
             try:
                 data = json_mod.loads(json_match.group(1))
                 experiments.append(data)
             except json_mod.JSONDecodeError:
                 pass
+    return experiments
+
+
+def sort_ml_experiments_by_metric(experiments: list) -> list[dict]:
+    """Return a new list sorted best-first (same ordering as the markdown report)."""
+    if not experiments:
+        return []
+    exp = list(experiments)
+    task_category = exp[0].get("task_category", "regression")
+    if task_category == "regression":
+        exp.sort(key=lambda x: x.get("r2", 0), reverse=True)
+    else:
+        exp.sort(key=lambda x: x.get("f1", 0), reverse=True)
+    return exp
+
+
+def _aggregate_ml_experiment(results: list, job: dict) -> str:
+    """
+    Custom aggregation for ml_experiment: parse JSON metrics from each
+    experiment result, rank them, and produce a structured comparison report.
+    Now includes CV scores, compute time breakdown, and more metrics.
+    """
+    import json as json_mod
+
+    experiments = parse_ml_experiments_from_task_rows(results)
 
     if not experiments:
         return _concatenate_results(results)
 
+    experiments = sort_ml_experiments_by_metric(experiments)
     task_category = experiments[0].get("task_category", "regression")
 
     if task_category == "regression":
-        experiments.sort(key=lambda x: x.get("r2", 0), reverse=True)
         primary_metric = "R²"
     else:
-        experiments.sort(key=lambda x: x.get("f1", 0), reverse=True)
         primary_metric = "F1"
 
     best = experiments[0]

--- a/backend/apis/jobs.py
+++ b/backend/apis/jobs.py
@@ -1,12 +1,21 @@
 import json
+from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import Response
 from database import get_pool
 from schemas import JobCreate
 from planner import plan_tasks
 from config import VALID_TASK_TYPES, MIN_PRIORITY, MAX_PRIORITY, MIN_REWARD
 from auth import get_session, ELEVATED_ROLES
+from aggregator import parse_ml_experiments_from_task_rows, sort_ml_experiments_by_metric
+from job_export import (
+    build_json_export,
+    experiments_to_csv,
+    json_dumps_export,
+    safe_export_filename,
+)
 
 router = APIRouter()
 
@@ -295,3 +304,83 @@ async def get_job_events(job_id: str) -> list[dict]:
             job_id,
         )
     return [dict(r) for r in rows]
+
+
+@router.get("/jobs/{job_id}/export")
+async def export_job_download(
+    job_id: str,
+    request: Request,
+    export_format: Literal["md", "json", "csv"] = Query("md", alias="format"),
+):
+    """Download completed job output: Markdown report, JSON (ranked metrics + report), or CSV table."""
+    try:
+        UUID(job_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Job not found") from None
+
+    user = await get_session(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        job = await conn.fetchrow("SELECT * FROM jobs WHERE id = $1::uuid", job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+
+        owner_id = str(job["user_id"]) if job["user_id"] is not None else None
+        is_owner = owner_id == user["id"]
+        is_elevated = user.get("role") in ELEVATED_ROLES
+        if not is_owner and not is_elevated:
+            raise HTTPException(
+                status_code=403, detail="You can only export your own jobs"
+            )
+
+        if job["status"] != "completed" or not job.get("final_output"):
+            raise HTTPException(
+                status_code=400,
+                detail="Job has no completed output to export yet",
+            )
+
+        rows = await conn.fetch(
+            """
+            SELECT jt.task_order, jt.task_name, tr.result_text
+            FROM job_tasks jt
+            JOIN task_results tr ON tr.task_id = jt.id
+            WHERE jt.job_id = $1::uuid AND jt.status = 'submitted'
+            ORDER BY jt.task_order
+            """,
+            job_id,
+        )
+
+    job_dict = dict(job)
+    results_list = [dict(r) for r in rows]
+    experiments = parse_ml_experiments_from_task_rows(results_list)
+    ranked = sort_ml_experiments_by_metric(experiments)
+
+    title = job_dict.get("title") or "job"
+    if export_format == "md":
+        body = job_dict.get("final_output") or ""
+        fn = safe_export_filename(title, job_id, "md")
+        return Response(
+            content=body.encode("utf-8"),
+            media_type="text/markdown; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{fn}"'},
+        )
+    if export_format == "json":
+        payload = build_json_export(job_dict, experiments, ranked)
+        fn = safe_export_filename(title, job_id, "json")
+        raw = json_dumps_export(payload)
+        return Response(
+            content=raw.encode("utf-8"),
+            media_type="application/json; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{fn}"'},
+        )
+
+    csv_body = experiments_to_csv(ranked)
+    fn = safe_export_filename(title, job_id, "csv")
+    return Response(
+        content=csv_body.encode("utf-8"),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{fn}"'},
+    )

--- a/backend/apis/workers.py
+++ b/backend/apis/workers.py
@@ -3,7 +3,11 @@ from fastapi import APIRouter, HTTPException
 from database import get_pool
 from schemas import TaskClaim, TaskComplete, TaskFail, WorkerHeartbeat, WorkerRegister, CacheLookup, CacheStore
 from aggregator import aggregate_job
-from config import MAX_TASK_FAILURE_RETRIES, TASK_FAILURE_RETRY_DELAY_SECONDS
+from config import (
+    MAX_TASK_FAILURE_RETRIES,
+    TASK_FAILURE_RETRY_DELAY_SECONDS,
+    TIER_FALLBACK_AFTER_MINUTES,
+)
 
 router = APIRouter()
 
@@ -41,6 +45,9 @@ async def claim_task(body: TaskClaim) -> dict:
         # and prioritize: tasks matching the worker's own tier first (so T4
         # workers grab T4 work before falling back to easier tasks), then by
         # job priority, then FIFO.
+        #
+        # Tier fallback: if a task has been queued longer than TIER_FALLBACK_AFTER_MINUTES,
+        # effective min_tier drops by 1 (min 1) so e.g. Tier 3 workers can claim Tier 4 tasks.
         if body.task_types:
             task = await conn.fetchrow(
                 """
@@ -52,7 +59,13 @@ async def claim_task(body: TaskClaim) -> dict:
                     WHERE jt.status = 'queued'
                       AND (jt.claim_after IS NULL OR jt.claim_after <= NOW())
                       AND j.task_type = ANY($2)
-                      AND COALESCE((jt.task_payload->>'min_tier')::int, 1) <= $3
+                      AND (
+                        CASE
+                          WHEN jt.created_at < NOW() - ($4 * INTERVAL '1 minute')
+                          THEN GREATEST(1, COALESCE((jt.task_payload->>'min_tier')::int, 1) - 1)
+                          ELSE COALESCE((jt.task_payload->>'min_tier')::int, 1)
+                        END
+                      ) <= $3
                     ORDER BY (COALESCE((jt.task_payload->>'min_tier')::int, 1) = $3) DESC,
                              j.priority DESC,
                              COALESCE((jt.task_payload->>'min_tier')::int, 1) DESC,
@@ -65,6 +78,7 @@ async def claim_task(body: TaskClaim) -> dict:
                 body.worker_node_id,
                 body.task_types,
                 body.worker_tier,
+                TIER_FALLBACK_AFTER_MINUTES,
             )
         else:
             task = await conn.fetchrow(
@@ -76,7 +90,13 @@ async def claim_task(body: TaskClaim) -> dict:
                     JOIN jobs j ON j.id = jt.job_id
                     WHERE jt.status = 'queued'
                       AND (jt.claim_after IS NULL OR jt.claim_after <= NOW())
-                      AND COALESCE((jt.task_payload->>'min_tier')::int, 1) <= $2
+                      AND (
+                        CASE
+                          WHEN jt.created_at < NOW() - ($3 * INTERVAL '1 minute')
+                          THEN GREATEST(1, COALESCE((jt.task_payload->>'min_tier')::int, 1) - 1)
+                          ELSE COALESCE((jt.task_payload->>'min_tier')::int, 1)
+                        END
+                      ) <= $2
                     ORDER BY (COALESCE((jt.task_payload->>'min_tier')::int, 1) = $2) DESC,
                              j.priority DESC,
                              COALESCE((jt.task_payload->>'min_tier')::int, 1) DESC,
@@ -88,6 +108,7 @@ async def claim_task(body: TaskClaim) -> dict:
                 """,
                 body.worker_node_id,
                 body.worker_tier,
+                TIER_FALLBACK_AFTER_MINUTES,
             )
 
         if not task:

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,6 +20,10 @@ WORKER_POLL_INTERVAL_SECONDS: int = 5
 TASK_FAILURE_RETRY_DELAY_SECONDS: int = 60
 MAX_TASK_FAILURE_RETRIES: int = 5
 
+# ── Tier fallback (issue #4) ──
+# If a task sat queued this long, effective min_tier drops by 1 so e.g. Tier 3 can claim Tier 4 work.
+TIER_FALLBACK_AFTER_MINUTES: int = 2
+
 # ── Auth ─────────────────────────────────────────────────────
 SESSION_MAX_AGE_SECONDS: int = 86400  # 24 hours
 

--- a/backend/job_export.py
+++ b/backend/job_export.py
@@ -1,0 +1,86 @@
+"""Build downloadable exports (CSV, JSON payload) from ML experiment task results."""
+
+import csv
+import io
+import json
+import re
+from typing import Any
+
+
+def safe_export_filename(title: str | None, job_id: str, ext: str) -> str:
+    raw = (title or "job").strip() or "job"
+    base = re.sub(r"[^\w\-.]+", "_", raw)[:50].strip("_") or "job"
+    short_id = str(job_id).replace("-", "")[:8]
+    return f"dcn_{base}_{short_id}.{ext}"
+
+
+def experiments_to_csv(experiments: list[dict[str, Any]]) -> str:
+    """Ranked rows; same metric ordering as the aggregator report."""
+    if not experiments:
+        return "message\nno_parsed_experiment_metrics_in_results\n"
+
+    cat = experiments[0].get("task_category", "regression")
+    buf = io.StringIO()
+
+    if cat == "regression":
+        fieldnames = [
+            "rank",
+            "model_type",
+            "model_display",
+            "r2",
+            "cv_r2_mean",
+            "cv_r2_std",
+            "mse",
+            "mae",
+            "total_time_seconds",
+            "n_features",
+        ]
+    else:
+        fieldnames = [
+            "rank",
+            "model_type",
+            "model_display",
+            "f1",
+            "accuracy",
+            "precision",
+            "recall",
+            "cv_f1_mean",
+            "cv_f1_std",
+            "total_time_seconds",
+            "n_features",
+        ]
+
+    w = csv.DictWriter(buf, fieldnames=fieldnames)
+    w.writeheader()
+    for i, exp in enumerate(experiments, 1):
+        row: dict[str, Any] = {"rank": i, "n_features": len(exp.get("features") or [])}
+        for k in fieldnames:
+            if k in ("rank", "n_features"):
+                continue
+            v = exp.get(k)
+            row[k] = "" if v is None else v
+        w.writerow({k: row.get(k, "") for k in fieldnames})
+
+    return buf.getvalue()
+
+
+def build_json_export(
+    job: dict,
+    experiments: list[dict[str, Any]],
+    ranked: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "job_id": str(job.get("id", "")),
+        "title": job.get("title"),
+        "task_type": job.get("task_type"),
+        "status": job.get("status"),
+        "created_at": job.get("created_at").isoformat() if job.get("created_at") else None,
+        "experiments_ranked": ranked,
+        "experiments_raw_count": len(experiments),
+        "markdown_report": job.get("final_output"),
+        "export_note": "experiments_ranked matches the comparison table in the markdown report",
+    }
+
+
+def json_dumps_export(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, default=str)

--- a/backend/planner.py
+++ b/backend/planner.py
@@ -102,26 +102,26 @@ def _plan_ml_experiment(input_payload: dict) -> list[dict]:
                 "task_description": f"5-fold CV GradientBoosting tuned (500 trees, depth=8, lr=0.05)",
                 "task_payload": {**base, "experiment_type": "gradient_boosting_regressor", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 500, "max_depth": 8, "learning_rate": 0.05}, "min_tier": 3},
             },
-            # ── Tier 4: datacenter-class heavy experiments ──
+            # ── Tier 4: heavy experiments (params halved vs original — feasible on strong workstations) ──
             {
                 "task_name": "experiment_rf_massive",
-                "task_description": f"10-fold CV RandomForest (1000 trees, depth=30, all features) on {display_name} — Tier 4 only",
-                "task_payload": {**base, "experiment_type": "random_forest_regressor", "features": all_features, "cv_folds": 10, "params": {"n_estimators": 1000, "max_depth": 30}, "min_tier": 4},
+                "task_description": f"5-fold CV RandomForest (500 trees, depth=20, all features) on {display_name} — Tier 4 (Tier 3 after queue wait)",
+                "task_payload": {**base, "experiment_type": "random_forest_regressor", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 500, "max_depth": 20}, "min_tier": 4},
             },
             {
                 "task_name": "experiment_gb_extreme",
-                "task_description": f"10-fold CV GradientBoosting (1000 trees, depth=12, lr=0.01) on {display_name} — Tier 4 only",
-                "task_payload": {**base, "experiment_type": "gradient_boosting_regressor", "features": all_features, "cv_folds": 10, "params": {"n_estimators": 1000, "max_depth": 12, "learning_rate": 0.01}, "min_tier": 4},
+                "task_description": f"5-fold CV GradientBoosting (500 trees, depth=8, lr=0.01) on {display_name} — Tier 4 (Tier 3 after queue wait)",
+                "task_payload": {**base, "experiment_type": "gradient_boosting_regressor", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 500, "max_depth": 8, "learning_rate": 0.01}, "min_tier": 4},
             },
             {
                 "task_name": "experiment_rf_mid_features_heavy",
-                "task_description": f"10-fold CV RandomForest (800 trees, depth=25, {len(mid_features)} features) — Tier 4 only",
-                "task_payload": {**base, "experiment_type": "random_forest_regressor", "features": mid_features, "cv_folds": 10, "params": {"n_estimators": 800, "max_depth": 25}, "min_tier": 4},
+                "task_description": f"5-fold CV RandomForest (400 trees, depth=15, {len(mid_features)} features) — Tier 4 (Tier 3 after queue wait)",
+                "task_payload": {**base, "experiment_type": "random_forest_regressor", "features": mid_features, "cv_folds": 5, "params": {"n_estimators": 400, "max_depth": 15}, "min_tier": 4},
             },
             {
                 "task_name": "experiment_gb_fine_tuned",
-                "task_description": f"10-fold CV GradientBoosting (800 trees, depth=10, lr=0.02) — Tier 4 only",
-                "task_payload": {**base, "experiment_type": "gradient_boosting_regressor", "features": all_features, "cv_folds": 10, "params": {"n_estimators": 800, "max_depth": 10, "learning_rate": 0.02}, "min_tier": 4},
+                "task_description": f"5-fold CV GradientBoosting (400 trees, depth=8, lr=0.02) — Tier 4 (Tier 3 after queue wait)",
+                "task_payload": {**base, "experiment_type": "gradient_boosting_regressor", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 400, "max_depth": 8, "learning_rate": 0.02}, "min_tier": 4},
             },
         ]
     else:
@@ -167,25 +167,25 @@ def _plan_ml_experiment(input_payload: dict) -> list[dict]:
                 "task_description": f"5-fold CV GradientBoosting tuned (500 trees, depth=8, lr=0.05)",
                 "task_payload": {**base, "experiment_type": "gradient_boosting_classifier", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 500, "max_depth": 8, "learning_rate": 0.05}, "min_tier": 3},
             },
-            # ── Tier 4: datacenter-class heavy experiments ──
+            # ── Tier 4: heavy experiments (params halved — feasible on strong workstations) ──
             {
                 "task_name": "experiment_rf_massive",
-                "task_description": f"10-fold CV RandomForest (1000 trees, depth=30, all features) on {display_name} — Tier 4 only",
-                "task_payload": {**base, "experiment_type": "random_forest_classifier", "features": all_features, "cv_folds": 10, "params": {"n_estimators": 1000, "max_depth": 30}, "min_tier": 4},
+                "task_description": f"5-fold CV RandomForest (500 trees, depth=20, all features) on {display_name} — Tier 4 (Tier 3 after queue wait)",
+                "task_payload": {**base, "experiment_type": "random_forest_classifier", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 500, "max_depth": 20}, "min_tier": 4},
             },
             {
                 "task_name": "experiment_gb_extreme",
-                "task_description": f"10-fold CV GradientBoosting (1000 trees, depth=12, lr=0.01) on {display_name} — Tier 4 only",
-                "task_payload": {**base, "experiment_type": "gradient_boosting_classifier", "features": all_features, "cv_folds": 10, "params": {"n_estimators": 1000, "max_depth": 12, "learning_rate": 0.01}, "min_tier": 4},
+                "task_description": f"5-fold CV GradientBoosting (500 trees, depth=8, lr=0.01) on {display_name} — Tier 4 (Tier 3 after queue wait)",
+                "task_payload": {**base, "experiment_type": "gradient_boosting_classifier", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 500, "max_depth": 8, "learning_rate": 0.01}, "min_tier": 4},
             },
             {
                 "task_name": "experiment_rf_mid_features_heavy",
-                "task_description": f"10-fold CV RandomForest (800 trees, depth=25, {len(mid_features)} features) — Tier 4 only",
-                "task_payload": {**base, "experiment_type": "random_forest_classifier", "features": mid_features, "cv_folds": 10, "params": {"n_estimators": 800, "max_depth": 25}, "min_tier": 4},
+                "task_description": f"5-fold CV RandomForest (400 trees, depth=15, {len(mid_features)} features) — Tier 4 (Tier 3 after queue wait)",
+                "task_payload": {**base, "experiment_type": "random_forest_classifier", "features": mid_features, "cv_folds": 5, "params": {"n_estimators": 400, "max_depth": 15}, "min_tier": 4},
             },
             {
                 "task_name": "experiment_gb_fine_tuned",
-                "task_description": f"10-fold CV GradientBoosting (800 trees, depth=10, lr=0.02) — Tier 4 only",
-                "task_payload": {**base, "experiment_type": "gradient_boosting_classifier", "features": all_features, "cv_folds": 10, "params": {"n_estimators": 800, "max_depth": 10, "learning_rate": 0.02}, "min_tier": 4},
+                "task_description": f"5-fold CV GradientBoosting (400 trees, depth=8, lr=0.02) — Tier 4 (Tier 3 after queue wait)",
+                "task_payload": {**base, "experiment_type": "gradient_boosting_classifier", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 400, "max_depth": 8, "learning_rate": 0.02}, "min_tier": 4},
             },
         ]

--- a/frontend/my-jobs/index.html
+++ b/frontend/my-jobs/index.html
@@ -70,6 +70,11 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
 }
 .job-delete-btn:hover{background:rgba(239,68,68,0.18);color:#f87171}
 
+.job-export-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:12px}
+.job-export-actions span{font-size:0.65rem;font-weight:600;text-transform:uppercase;letter-spacing:0.4px;color:var(--dim)}
+.job-export-btn{background:rgba(124,58,237,0.12);border:1px solid rgba(124,58,237,0.25);color:#c4b5fd;padding:5px 10px;border-radius:8px;font-size:0.72rem;font-weight:600;cursor:pointer;font-family:inherit}
+.job-export-btn:hover{background:rgba(124,58,237,0.22);color:#fff;border-color:rgba(124,58,237,0.45)}
+
 .type-badge{padding:3px 10px;border-radius:20px;font-size:0.65rem;font-weight:700;text-transform:uppercase;letter-spacing:0.5px}
 .type-ml_experiment{background:rgba(124,58,237,0.12);color:#a78bfa}
 
@@ -380,7 +385,15 @@ function showJobDetails(job) {
   if (outputEl && job.final_output) {
     const cleaned = job.final_output.replace(/^=== \S+ ===\s*\n?/gm, '');
     const preview = cleaned.length > 4000 ? cleaned.substring(0, 4000) + '\n\n*... (truncated — view full output in Results)*' : cleaned;
+    const exports = job.status === 'completed' ? `
+      <div class="job-export-actions">
+        <span>Download</span>
+        <button type="button" class="job-export-btn" onclick="event.stopPropagation();downloadJobExport('${job.id}','md')">Markdown</button>
+        <button type="button" class="job-export-btn" onclick="event.stopPropagation();downloadJobExport('${job.id}','json')">JSON</button>
+        <button type="button" class="job-export-btn" onclick="event.stopPropagation();downloadJobExport('${job.id}','csv')">CSV</button>
+      </div>` : '';
     outputEl.innerHTML = `
+      ${exports}
       <div class="output-label">Final Output</div>
       <div class="output-block">${marked.parse(preview)}</div>
     `;
@@ -400,6 +413,41 @@ function escapeHtml(str) {
   const d = document.createElement('div');
   d.textContent = str;
   return d.innerHTML;
+}
+
+async function downloadJobExport(jobId, fmt) {
+  try {
+    const r = await fetch(`${API}/jobs/${jobId}/export?format=${fmt}`, { credentials: 'include' });
+    if (r.status === 401) {
+      alert('Sign in to download exports.');
+      return;
+    }
+    if (!r.ok) {
+      let msg = await r.text();
+      try {
+        const j = JSON.parse(msg);
+        if (j.detail) msg = typeof j.detail === 'string' ? j.detail : JSON.stringify(j.detail);
+      } catch (_) {}
+      alert('Download failed: ' + msg.slice(0, 300));
+      return;
+    }
+    const blob = await r.blob();
+    let name = 'dcn-export.' + (fmt === 'md' ? 'md' : fmt === 'json' ? 'json' : 'csv');
+    const cd = r.headers.get('Content-Disposition');
+    if (cd) {
+      const m = cd.match(/filename="([^"]+)"/);
+      if (m) name = m[1];
+    }
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = name;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(a.href);
+  } catch (e) {
+    alert('Download failed.');
+  }
 }
 
 async function boot() {

--- a/frontend/public_page/index.html
+++ b/frontend/public_page/index.html
@@ -864,6 +864,38 @@
       background: rgba(124,58,237,0.08);
     }
 
+    .export-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .export-bar-label {
+      font-size: 0.68rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: rgba(255,255,255,0.35);
+      margin-right: 4px;
+    }
+    .btn-export {
+      background: rgba(124,58,237,0.12);
+      border: 1px solid rgba(124,58,237,0.25);
+      color: #c4b5fd;
+      padding: 6px 12px;
+      border-radius: 8px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      cursor: pointer;
+      font-family: 'Inter', inherit;
+      transition: all 0.15s ease;
+    }
+    .btn-export:hover {
+      background: rgba(124,58,237,0.22);
+      color: #fff;
+      border-color: rgba(124,58,237,0.45);
+    }
+
     /* Task description panel */
     .task-description-panel {
       position: sticky;
@@ -1068,9 +1100,17 @@
 
       <!-- Output -->
       <div class="card output-section" id="outputCard">
-        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:20px;">
+        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:20px; flex-wrap:wrap; gap:12px;">
           <h2 style="margin-bottom:0">Final Output</h2>
-          <button class="btn-secondary" onclick="resetForm()">New Job</button>
+          <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap;">
+            <div class="export-bar" id="exportBar" style="display:none;" title="Requires signed-in session (same as submit)">
+              <span class="export-bar-label">Download</span>
+              <button type="button" class="btn-export" onclick="downloadJobExport('md')">Markdown</button>
+              <button type="button" class="btn-export" onclick="downloadJobExport('json')">JSON</button>
+              <button type="button" class="btn-export" onclick="downloadJobExport('csv')">CSV</button>
+            </div>
+            <button class="btn-secondary" onclick="resetForm()">New Job</button>
+          </div>
         </div>
         <div class="output-block" id="outputBlock"></div>
       </div>
@@ -1327,8 +1367,8 @@
 
       try {
         const [jobResp, tasksResp] = await Promise.all([
-          fetch(`${API}/jobs/${currentJobId}`),
-          fetch(`${API}/jobs/${currentJobId}/tasks`),
+          fetch(`${API}/jobs/${currentJobId}`, { credentials: 'include' }),
+          fetch(`${API}/jobs/${currentJobId}/tasks`, { credentials: 'include' }),
         ]);
 
         const job = await jobResp.json();
@@ -1364,6 +1404,8 @@
         if (job.status === 'completed' && job.final_output) {
           clearInterval(pollInterval);
           document.getElementById('outputCard').style.display = 'block';
+          const eb = document.getElementById('exportBar');
+          if (eb) eb.style.display = 'flex';
           renderOutput(job.final_output, job.task_type);
           loadTimingComparison();
         }
@@ -1429,7 +1471,7 @@
     async function loadTimingComparison() {
       if (!currentJobId) return;
       try {
-        const resp = await fetch(`${API}/jobs/${currentJobId}/timing`);
+        const resp = await fetch(`${API}/jobs/${currentJobId}/timing`, { credentials: 'include' });
         if (!resp.ok) return;
         const timing = await resp.json();
 
@@ -1488,9 +1530,48 @@
       }
     }
 
+    async function downloadJobExport(fmt) {
+      if (!currentJobId) return;
+      try {
+        const r = await fetch(`${API}/jobs/${currentJobId}/export?format=${fmt}`, { credentials: 'include' });
+        if (r.status === 401) {
+          alert('Sign in to download exports (same account as job submit).');
+          return;
+        }
+        if (!r.ok) {
+          let msg = await r.text();
+          try {
+            const j = JSON.parse(msg);
+            if (j.detail) msg = typeof j.detail === 'string' ? j.detail : JSON.stringify(j.detail);
+          } catch (_) {}
+          alert('Download failed: ' + msg.slice(0, 300));
+          return;
+        }
+        const blob = await r.blob();
+        let name = 'dcn-export.' + (fmt === 'md' ? 'md' : fmt === 'json' ? 'json' : 'csv');
+        const cd = r.headers.get('Content-Disposition');
+        if (cd) {
+          const m = cd.match(/filename="([^"]+)"/);
+          if (m) name = m[1];
+        }
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = name;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(a.href);
+      } catch (e) {
+        alert('Download failed.');
+      }
+    }
+
     function resetForm() {
       currentJobId = null;
       if (pollInterval) clearInterval(pollInterval);
+
+      const eb = document.getElementById('exportBar');
+      if (eb) eb.style.display = 'none';
 
       document.getElementById('formCard').style.display = 'block';
       document.getElementById('taskDescriptionPanel').style.display = '';


### PR DESCRIPTION
Pushed because `master` is protected (PR required).

**Job exports**
- `GET /jobs/{id}/export?format=md|json|csv` with shared ML ranking helpers and `job_export.py`
- Public submit page + My Jobs download UI

**Workers / planner**
- Tier fallback after `TIER_FALLBACK_AFTER_MINUTES` so queued Tier 4 tasks can be claimed by Tier 3
- Tier 4 ML experiments tuned down for feasibility; copy updated

Made with [Cursor](https://cursor.com)