### PR TITLE
fix: Worker Logs task history (credentials + error handling)

### DIFF
--- a/backend/apis/monitor.py
+++ b/backend/apis/monitor.py
@@ -1,6 +1,12 @@
-from fastapi import APIRouter, Request
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
+
 from database import get_pool
 from config import HEARTBEAT_OFFLINE_SECONDS
+
+logger = logging.getLogger("dcn")
 
 router = APIRouter(prefix="/monitor")
 
@@ -137,26 +143,31 @@ async def delete_worker(worker_id: str, request: Request) -> dict:
 async def worker_history(worker_id: str) -> list[dict]:
     """Return task history for a specific worker node."""
     pool = await get_pool()
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            """
-            SELECT
-                tr.id,
-                tr.task_id,
-                tr.result_text,
-                tr.execution_time_seconds,
-                tr.status,
-                tr.submitted_at as created_at,
-                jt.task_name,
-                jt.job_id,
-                j.title as job_title
-            FROM task_results tr
-            JOIN job_tasks jt ON jt.id = tr.task_id
-            JOIN jobs j ON j.id = jt.job_id
-            WHERE tr.worker_node_id = $1::uuid
-            ORDER BY tr.submitted_at DESC
-            LIMIT 100
-            """,
-            worker_id,
-        )
-    return [dict(r) for r in rows]
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT
+                    tr.id,
+                    tr.task_id,
+                    tr.result_text,
+                    tr.execution_time_seconds,
+                    tr.status,
+                    tr.submitted_at AS created_at,
+                    jt.task_name,
+                    jt.job_id,
+                    j.title AS job_title
+                FROM task_results tr
+                JOIN job_tasks jt ON jt.id = tr.task_id
+                JOIN jobs j ON j.id = jt.job_id
+                WHERE tr.worker_node_id = $1::uuid
+                ORDER BY tr.submitted_at DESC NULLS LAST
+                LIMIT 100
+                """,
+                worker_id,
+            )
+    except Exception as e:
+        logger.exception("worker_history query failed for worker_id=%s", worker_id)
+        raise HTTPException(status_code=500, detail="Failed to load worker history") from e
+
+    return jsonable_encoder([dict(r) for r in rows])

--- a/frontend/worker-logs/index.html
+++ b/frontend/worker-logs/index.html
@@ -180,8 +180,18 @@ let allWorkers = [];
 
 async function loadWorkers() {
   try {
-    const resp = await fetch(`${API}/monitor/workers`);
-    allWorkers = await resp.json();
+    const resp = await fetch(`${API}/monitor/workers`, { credentials: 'include' });
+    const data = await resp.json();
+    if (!resp.ok) {
+      const msg = (data && data.detail) ? (typeof data.detail === 'string' ? data.detail : JSON.stringify(data.detail)) : resp.statusText;
+      document.getElementById('workersGrid').innerHTML = `<div style="color:var(--dim)">Failed to load workers (${resp.status}): ${escapeHtml(msg)}</div>`;
+      return;
+    }
+    if (!Array.isArray(data)) {
+      document.getElementById('workersGrid').innerHTML = '<div style="color:var(--dim)">Failed to load workers: unexpected response</div>';
+      return;
+    }
+    allWorkers = data;
     renderWorkers();
   } catch(e) {
     document.getElementById('workersGrid').innerHTML = '<div style="color:var(--dim)">Failed to load workers</div>';
@@ -226,10 +236,20 @@ async function selectWorker(workerId) {
   section.innerHTML = '<div style="color:var(--dim);font-size:0.85rem;padding:20px 0">Loading task history...</div>';
 
   try {
-    const resp = await fetch(`${API}/monitor/worker-history/${workerId}`);
+    const resp = await fetch(`${API}/monitor/worker-history/${encodeURIComponent(workerId)}`, { credentials: 'include' });
     const history = await resp.json();
 
     const workerName = worker ? escapeHtml(worker.node_name) : workerId.substring(0,8);
+
+    if (!resp.ok) {
+      const msg = (history && history.detail) ? (typeof history.detail === 'string' ? history.detail : JSON.stringify(history.detail)) : resp.statusText;
+      section.innerHTML = `<div style="color:var(--dim)">Could not load history (${resp.status}): ${escapeHtml(msg)}</div>`;
+      return;
+    }
+    if (!Array.isArray(history)) {
+      section.innerHTML = `<div style="color:var(--dim)">Could not load history: server returned non-list response.</div>`;
+      return;
+    }
 
     if (!history.length) {
       section.innerHTML = `


### PR DESCRIPTION
Fixes misleading "Failed to load worker history" when the API returned JSON errors (`detail`) instead of an array — the UI called `.filter` on a non-array.

- **worker-logs:** `credentials: 'include'` on monitor fetches; check `resp.ok` and `Array.isArray`; show status + detail on failure
- **monitor:** `jsonable_encoder` for worker history rows; log and 500 on query failure

Local `master` reset after push (branch protection).

Made with [Cursor](https://cursor.com)