### PR TITLE
feat: add Contact Us, Report Bug pages, and verify task requeue

### DIFF
--- a/backend/apis/feedback.py
+++ b/backend/apis/feedback.py
@@ -1,0 +1,109 @@
+"""API routes for bug reports and contact messages."""
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+from typing import Optional
+from database import get_pool
+from auth import get_session, ELEVATED_ROLES
+
+router = APIRouter()
+
+
+class BugReport(BaseModel):
+    subject: str
+    description: str
+    page_url: Optional[str] = None
+
+
+class ContactMessage(BaseModel):
+    name: str
+    email: str
+    subject: str = "general"
+    message: str
+
+
+@router.post("/bugs")
+async def create_bug_report(body: BugReport, request: Request) -> dict:
+    """Submit a bug report. Requires authentication."""
+    user = await get_session(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    if not body.subject.strip() or not body.description.strip():
+        raise HTTPException(status_code=400, detail="Subject and description are required")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO bug_reports (user_id, subject, description, page_url)
+            VALUES ($1::uuid, $2, $3, $4)
+            RETURNING id, created_at
+            """,
+            user["id"],
+            body.subject.strip(),
+            body.description.strip(),
+            body.page_url or None,
+        )
+    return {"id": str(row["id"]), "created_at": str(row["created_at"])}
+
+
+@router.get("/bugs")
+async def list_bug_reports(request: Request) -> list[dict]:
+    """List all bug reports. Admin/CEO only."""
+    user = await get_session(request)
+    if not user or user.get("role") not in ELEVATED_ROLES:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT b.*, u.email AS reporter_email, u.name AS reporter_name
+            FROM bug_reports b
+            LEFT JOIN users u ON u.id = b.user_id
+            ORDER BY b.created_at DESC
+            """
+        )
+    return [dict(r) for r in rows]
+
+
+@router.post("/contact")
+async def create_contact_message(body: ContactMessage, request: Request) -> dict:
+    """Submit a contact message. Works for both authenticated and anonymous users."""
+    if not body.name.strip() or not body.email.strip() or not body.message.strip():
+        raise HTTPException(status_code=400, detail="Name, email, and message are required")
+
+    user = await get_session(request)
+    user_id = user["id"] if user else None
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            INSERT INTO contact_messages (user_id, name, email, subject, message)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id, created_at
+            """,
+            user_id,
+            body.name.strip(),
+            body.email.strip(),
+            body.subject,
+            body.message.strip(),
+        )
+    return {"id": str(row["id"]), "created_at": str(row["created_at"])}
+
+
+@router.get("/contact/messages")
+async def list_contact_messages(request: Request) -> list[dict]:
+    """List all contact messages. Admin/CEO only."""
+    user = await get_session(request)
+    if not user or user.get("role") not in ELEVATED_ROLES:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT * FROM contact_messages ORDER BY created_at DESC"
+        )
+    return [dict(r) for r in rows]

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -221,7 +221,7 @@ ADMIN_PAGES = {"/ops", "/results", "/worker-logs", "/admin/users"}
 # API routes that require admin (or ceo) role
 ADMIN_API_PREFIXES = ["/monitor/"]
 # Pages that require any authenticated user (non-admin)
-AUTH_REQUIRED_PAGES = {"/submit", "/my-jobs"}
+AUTH_REQUIRED_PAGES = {"/submit", "/my-jobs", "/report-bug"}
 # Prefixes that don't need auth
 # OAuth callbacks must be reachable without a session; do not use blanket "/auth/" or /auth/users would be public.
 PUBLIC_PREFIXES = [
@@ -235,4 +235,5 @@ PUBLIC_PREFIXES = [
     "/auth/logout",
     "/stats",
     "/datasets",
+    "/contact",
 ]

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ from database import get_pool, close_pool
 from apis.jobs import router as jobs_router
 from apis.monitor import router as monitor_router
 from apis.workers import router as workers_router
+from apis.feedback import router as feedback_router
 from auth import (
     find_or_create_oauth_user, create_session, get_session, destroy_session,
     update_user_role, list_users,
@@ -41,6 +42,8 @@ MYJOBS_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "my-jobs"
 ERROR_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "error")
 WORKER_LOGS_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "worker-logs")
 ADMIN_USERS_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "admin-users")
+CONTACT_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "contact")
+REPORT_BUG_DIR = os.path.join(os.path.dirname(__file__), "..", "frontend", "report-bug")
 
 
 async def _maintenance_loop():
@@ -234,6 +237,26 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error("job_tasks retry columns migration failed: %s", e, exc_info=True)
             raise
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS bug_reports (
+                id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                user_id     UUID REFERENCES dcn_users(id),
+                subject     TEXT NOT NULL,
+                description TEXT NOT NULL,
+                page_url    TEXT,
+                status      VARCHAR DEFAULT 'open',
+                created_at  TIMESTAMPTZ DEFAULT now()
+            );
+            CREATE TABLE IF NOT EXISTS contact_messages (
+                id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                user_id     UUID REFERENCES dcn_users(id),
+                name        TEXT NOT NULL,
+                email       TEXT NOT NULL,
+                subject     TEXT NOT NULL DEFAULT 'general',
+                message     TEXT NOT NULL,
+                created_at  TIMESTAMPTZ DEFAULT now()
+            );
+        """)
     maintenance_task = asyncio.create_task(_maintenance_loop())
     yield
     maintenance_task.cancel()
@@ -253,6 +276,7 @@ app.add_middleware(
 app.include_router(jobs_router)
 app.include_router(monitor_router)
 app.include_router(workers_router)
+app.include_router(feedback_router)
 
 
 # ── Auth middleware ──────────────────────────────────────────────
@@ -549,6 +573,19 @@ async def serve_worker_logs():
 @app.get("/admin/users")
 async def serve_admin_users():
     response = FileResponse(os.path.join(ADMIN_USERS_DIR, "index.html"))
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    return response
+
+
+@app.get("/contact")
+async def serve_contact():
+    return FileResponse(os.path.join(CONTACT_DIR, "index.html"))
+
+
+@app.get("/report-bug")
+async def serve_report_bug():
+    response = FileResponse(os.path.join(REPORT_BUG_DIR, "index.html"))
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
     response.headers["Pragma"] = "no-cache"
     return response

--- a/frontend/contact/index.html
+++ b/frontend/contact/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DCN — Contact Us</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#14161e;--surface:rgba(255,255,255,0.06);--surface2:rgba(255,255,255,0.08);
+  --border:rgba(255,255,255,0.10);--border2:rgba(255,255,255,0.14);
+  --text:#e8e8ec;--muted:#b4b4bc;--dim:#8a8a96;--dark:#52525b;
+  --accent:#7c3aed;--accent2:#6366f1;--accent3:#3b82f6;
+  --green:#22c55e;--red:#ef4444;--yellow:#eab308;
+}
+body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;-webkit-font-smoothing:antialiased}
+.app-layout{display:flex;min-height:100vh}
+.sidebar{width:240px;min-width:240px;background:rgba(16,18,26,0.55);backdrop-filter:blur(24px);-webkit-backdrop-filter:blur(24px);border-right:1px solid rgba(255,255,255,0.06);display:flex;flex-direction:column;padding:24px 0;position:fixed;top:0;left:0;bottom:0;z-index:10}
+.sidebar-logo{font-weight:800;font-size:20px;background:linear-gradient(135deg,#a78bfa,#60a5fa);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-decoration:none;padding:0 24px;margin-bottom:8px;display:block}
+.sidebar-role{font-size:0.68rem;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:#7c3aed;padding:0 24px;margin-bottom:24px}
+.sidebar-nav{display:flex;flex-direction:column;gap:2px;flex:1;padding:0 12px}
+.sidebar-nav a{display:flex;align-items:center;gap:10px;color:rgba(255,255,255,0.45);text-decoration:none;font-size:0.88rem;font-weight:500;padding:10px 14px;border-radius:10px;transition:all 0.15s}
+.sidebar-nav a:hover{color:#fff;background:rgba(255,255,255,0.04)}
+.sidebar-nav a.active{color:#fff;background:linear-gradient(135deg,rgba(124,58,237,0.15),rgba(59,130,246,0.10));border:1px solid rgba(124,58,237,0.2)}
+.sidebar-nav a svg{width:18px;height:18px;flex-shrink:0}
+.sidebar-bottom{padding:16px 12px 0;border-top:1px solid rgba(255,255,255,0.06);margin-top:auto}
+.sidebar-user{padding:10px 14px;display:flex;align-items:center;gap:10px;margin-bottom:4px}
+.sidebar-user-avatar{width:32px;height:32px;border-radius:8px;background:linear-gradient(135deg,#7c3aed,#3b82f6);display:flex;align-items:center;justify-content:center;font-size:0.82rem;font-weight:700;color:#fff;flex-shrink:0}
+.sidebar-user-name{font-size:0.85rem;font-weight:600;color:#fff}
+.sidebar-user-role{font-size:0.7rem;color:rgba(255,255,255,0.35);text-transform:capitalize}
+.sidebar-signout{display:flex;align-items:center;gap:10px;color:rgba(255,255,255,0.35);text-decoration:none;font-size:0.82rem;font-weight:500;padding:10px 14px;border-radius:10px;transition:all 0.15s}
+.sidebar-signout:hover{color:#ef4444;background:rgba(239,68,68,0.06)}
+.sidebar-signout svg{width:16px;height:16px}
+.main-content{margin-left:240px;flex:1;min-width:0;padding:32px 40px 60px}
+.page-title{font-size:1.5rem;font-weight:800;color:#fff;letter-spacing:-0.5px;margin-bottom:4px}
+.page-subtitle{font-size:0.85rem;color:var(--dim);margin-bottom:28px}
+
+.form-card{max-width:560px;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.07);border-radius:16px;padding:28px 32px}
+.form-group{margin-bottom:18px}
+.form-label{display:block;font-size:0.78rem;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;color:rgba(255,255,255,0.5);margin-bottom:6px}
+.form-input,.form-select,.form-textarea{width:100%;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);border-radius:10px;padding:10px 14px;color:#fff;font-family:inherit;font-size:0.88rem;outline:none;transition:border-color 0.15s}
+.form-input:focus,.form-select:focus,.form-textarea:focus{border-color:rgba(124,58,237,0.5)}
+.form-select{appearance:none;cursor:pointer}
+.form-textarea{min-height:120px;resize:vertical}
+.form-btn{display:inline-flex;align-items:center;gap:8px;padding:12px 28px;background:linear-gradient(135deg,var(--accent),var(--accent3));color:#fff;border:none;border-radius:10px;font-family:inherit;font-size:0.88rem;font-weight:600;cursor:pointer;transition:all 0.2s}
+.form-btn:hover{transform:translateY(-1px);box-shadow:0 6px 20px rgba(124,58,237,0.3)}
+.form-btn:disabled{opacity:0.5;cursor:not-allowed;transform:none}
+.success-msg{display:none;padding:16px 20px;background:rgba(34,197,94,0.1);border:1px solid rgba(34,197,94,0.25);border-radius:12px;color:#4ade80;font-size:0.88rem;margin-bottom:18px}
+.error-msg{display:none;padding:16px 20px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.25);border-radius:12px;color:#f87171;font-size:0.88rem;margin-bottom:18px}
+
+@media(max-width:768px){.sidebar{display:none}.main-content{margin-left:0;padding:24px 20px}}
+</style>
+</head>
+<body>
+<div class="app-layout">
+<aside class="sidebar" id="sidebar">
+  <a href="/" class="sidebar-logo">DCN</a>
+  <div class="sidebar-role" id="sidebarRole">Customer</div>
+  <nav class="sidebar-nav" id="sidebarNav">
+    <a href="/submit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>Submit Job</a>
+    <a href="/my-jobs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/></svg>My Jobs</a>
+    <a href="/report-bug"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>Report Bug</a>
+    <a href="/contact" class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>Contact Us</a>
+  </nav>
+  <div class="sidebar-bottom">
+    <div class="sidebar-user" id="sidebarUser" style="display:none">
+      <div class="sidebar-user-avatar" id="userAvatar">?</div>
+      <div><div class="sidebar-user-name" id="userName">--</div><div class="sidebar-user-role" id="userRoleLabel">--</div></div>
+    </div>
+    <a href="/auth/logout" class="sidebar-signout" id="signoutLink" style="display:none">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16,17 21,12 16,7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>Sign Out
+    </a>
+    <a href="/login" class="sidebar-signout" id="signinLink">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h4a2 2 0 012 2v14a2 2 0 01-2 2h-4"/><polyline points="10,17 15,12 10,7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>Sign In
+    </a>
+  </div>
+</aside>
+
+<script>
+let currentUser=null;
+fetch('/auth/me',{credentials:'include'}).then(r=>r.ok?r.json():null).then(u=>{
+  if(!u)return;
+  currentUser=u;
+  document.getElementById('sidebarUser').style.display='flex';
+  document.getElementById('signoutLink').style.display='flex';
+  document.getElementById('signinLink').style.display='none';
+  document.getElementById('userName').textContent=u.name||u.email;
+  document.getElementById('userRoleLabel').textContent=u.role;
+  const av=document.getElementById('userAvatar');
+  if(u.avatar_url){av.innerHTML='<img src="'+u.avatar_url+'" style="width:100%;height:100%;border-radius:50%;object-fit:cover">';}
+  else{av.textContent=(u.name||u.email).charAt(0).toUpperCase();}
+  document.getElementById('contactName').value=u.name||'';
+  document.getElementById('contactEmail').value=u.email||'';
+  if(u.role==='admin'||u.role==='ceo'){
+    document.getElementById('sidebarRole').textContent='Admin Panel';
+  }
+}).catch(()=>{});
+</script>
+
+<div class="main-content">
+  <h1 class="page-title">Contact Us</h1>
+  <p class="page-subtitle">Questions, feedback, or partnership inquiries — we'd love to hear from you.</p>
+
+  <div class="form-card">
+    <div class="success-msg" id="successMsg">Message sent! We'll get back to you soon.</div>
+    <div class="error-msg" id="errorMsg"></div>
+
+    <div class="form-group">
+      <label class="form-label">Name</label>
+      <input class="form-input" id="contactName" placeholder="Your name">
+    </div>
+    <div class="form-group">
+      <label class="form-label">Email</label>
+      <input class="form-input" id="contactEmail" type="email" placeholder="you@example.com">
+    </div>
+    <div class="form-group">
+      <label class="form-label">Subject</label>
+      <select class="form-select" id="contactSubject">
+        <option value="general">General</option>
+        <option value="support">Support</option>
+        <option value="bug">Bug Report</option>
+        <option value="partnership">Partnership</option>
+        <option value="other">Other</option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label class="form-label">Message</label>
+      <textarea class="form-textarea" id="contactMessage" placeholder="How can we help?"></textarea>
+    </div>
+    <button class="form-btn" id="sendBtn" onclick="sendMessage()">Send Message</button>
+  </div>
+</div>
+</div>
+
+<script>
+async function sendMessage(){
+  const name=document.getElementById('contactName').value.trim();
+  const email=document.getElementById('contactEmail').value.trim();
+  const subject=document.getElementById('contactSubject').value;
+  const message=document.getElementById('contactMessage').value.trim();
+  const errEl=document.getElementById('errorMsg');
+  const okEl=document.getElementById('successMsg');
+  errEl.style.display='none'; okEl.style.display='none';
+
+  if(!name||!email||!message){errEl.textContent='Please fill in all required fields.';errEl.style.display='block';return;}
+
+  const btn=document.getElementById('sendBtn');
+  btn.disabled=true; btn.textContent='Sending...';
+  try{
+    const r=await fetch('/contact',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({name,email,subject,message})});
+    if(!r.ok){const e=await r.json().catch(()=>({}));throw new Error(e.detail||'Failed to send');}
+    okEl.style.display='block';
+    document.getElementById('contactMessage').value='';
+  }catch(e){errEl.textContent=e.message;errEl.style.display='block';}
+  finally{btn.disabled=false;btn.textContent='Send Message';}
+}
+</script>
+</body>
+</html>

--- a/frontend/report-bug/index.html
+++ b/frontend/report-bug/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DCN — Report Bug</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+  --bg:#14161e;--surface:rgba(255,255,255,0.06);--surface2:rgba(255,255,255,0.08);
+  --border:rgba(255,255,255,0.10);--border2:rgba(255,255,255,0.14);
+  --text:#e8e8ec;--muted:#b4b4bc;--dim:#8a8a96;--dark:#52525b;
+  --accent:#7c3aed;--accent2:#6366f1;--accent3:#3b82f6;
+  --green:#22c55e;--red:#ef4444;--yellow:#eab308;
+}
+body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--text);min-height:100vh;-webkit-font-smoothing:antialiased}
+.app-layout{display:flex;min-height:100vh}
+.sidebar{width:240px;min-width:240px;background:rgba(16,18,26,0.55);backdrop-filter:blur(24px);-webkit-backdrop-filter:blur(24px);border-right:1px solid rgba(255,255,255,0.06);display:flex;flex-direction:column;padding:24px 0;position:fixed;top:0;left:0;bottom:0;z-index:10}
+.sidebar-logo{font-weight:800;font-size:20px;background:linear-gradient(135deg,#a78bfa,#60a5fa);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-decoration:none;padding:0 24px;margin-bottom:8px;display:block}
+.sidebar-role{font-size:0.68rem;font-weight:600;text-transform:uppercase;letter-spacing:1px;color:#7c3aed;padding:0 24px;margin-bottom:24px}
+.sidebar-nav{display:flex;flex-direction:column;gap:2px;flex:1;padding:0 12px}
+.sidebar-nav a{display:flex;align-items:center;gap:10px;color:rgba(255,255,255,0.45);text-decoration:none;font-size:0.88rem;font-weight:500;padding:10px 14px;border-radius:10px;transition:all 0.15s}
+.sidebar-nav a:hover{color:#fff;background:rgba(255,255,255,0.04)}
+.sidebar-nav a.active{color:#fff;background:linear-gradient(135deg,rgba(124,58,237,0.15),rgba(59,130,246,0.10));border:1px solid rgba(124,58,237,0.2)}
+.sidebar-nav a svg{width:18px;height:18px;flex-shrink:0}
+.sidebar-bottom{padding:16px 12px 0;border-top:1px solid rgba(255,255,255,0.06);margin-top:auto}
+.sidebar-user{padding:10px 14px;display:flex;align-items:center;gap:10px;margin-bottom:4px}
+.sidebar-user-avatar{width:32px;height:32px;border-radius:8px;background:linear-gradient(135deg,#7c3aed,#3b82f6);display:flex;align-items:center;justify-content:center;font-size:0.82rem;font-weight:700;color:#fff;flex-shrink:0}
+.sidebar-user-name{font-size:0.85rem;font-weight:600;color:#fff}
+.sidebar-user-role{font-size:0.7rem;color:rgba(255,255,255,0.35);text-transform:capitalize}
+.sidebar-signout{display:flex;align-items:center;gap:10px;color:rgba(255,255,255,0.35);text-decoration:none;font-size:0.82rem;font-weight:500;padding:10px 14px;border-radius:10px;transition:all 0.15s}
+.sidebar-signout:hover{color:#ef4444;background:rgba(239,68,68,0.06)}
+.sidebar-signout svg{width:16px;height:16px}
+.main-content{margin-left:240px;flex:1;min-width:0;padding:32px 40px 60px}
+.page-title{font-size:1.5rem;font-weight:800;color:#fff;letter-spacing:-0.5px;margin-bottom:4px}
+.page-subtitle{font-size:0.85rem;color:var(--dim);margin-bottom:28px}
+
+.form-card{max-width:560px;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.07);border-radius:16px;padding:28px 32px}
+.form-group{margin-bottom:18px}
+.form-label{display:block;font-size:0.78rem;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;color:rgba(255,255,255,0.5);margin-bottom:6px}
+.form-input,.form-textarea{width:100%;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);border-radius:10px;padding:10px 14px;color:#fff;font-family:inherit;font-size:0.88rem;outline:none;transition:border-color 0.15s}
+.form-input:focus,.form-textarea:focus{border-color:rgba(124,58,237,0.5)}
+.form-textarea{min-height:140px;resize:vertical}
+.form-hint{font-size:0.75rem;color:var(--dark);margin-top:4px}
+.form-btn{display:inline-flex;align-items:center;gap:8px;padding:12px 28px;background:linear-gradient(135deg,var(--accent),var(--accent3));color:#fff;border:none;border-radius:10px;font-family:inherit;font-size:0.88rem;font-weight:600;cursor:pointer;transition:all 0.2s}
+.form-btn:hover{transform:translateY(-1px);box-shadow:0 6px 20px rgba(124,58,237,0.3)}
+.form-btn:disabled{opacity:0.5;cursor:not-allowed;transform:none}
+.success-msg{display:none;padding:16px 20px;background:rgba(34,197,94,0.1);border:1px solid rgba(34,197,94,0.25);border-radius:12px;color:#4ade80;font-size:0.88rem;margin-bottom:18px}
+.error-msg{display:none;padding:16px 20px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.25);border-radius:12px;color:#f87171;font-size:0.88rem;margin-bottom:18px}
+
+@media(max-width:768px){.sidebar{display:none}.main-content{margin-left:0;padding:24px 20px}}
+</style>
+</head>
+<body>
+<div class="app-layout">
+<aside class="sidebar" id="sidebar">
+  <a href="/" class="sidebar-logo">DCN</a>
+  <div class="sidebar-role" id="sidebarRole">Customer</div>
+  <nav class="sidebar-nav" id="sidebarNav">
+    <a href="/submit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>Submit Job</a>
+    <a href="/my-jobs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2"/><rect x="9" y="3" width="6" height="4" rx="1"/></svg>My Jobs</a>
+    <a href="/report-bug" class="active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>Report Bug</a>
+    <a href="/contact"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>Contact Us</a>
+  </nav>
+  <div class="sidebar-bottom">
+    <div class="sidebar-user" id="sidebarUser" style="display:none">
+      <div class="sidebar-user-avatar" id="userAvatar">?</div>
+      <div><div class="sidebar-user-name" id="userName">--</div><div class="sidebar-user-role" id="userRoleLabel">--</div></div>
+    </div>
+    <a href="/auth/logout" class="sidebar-signout" id="signoutLink" style="display:none">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16,17 21,12 16,7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>Sign Out
+    </a>
+    <a href="/login" class="sidebar-signout" id="signinLink">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h4a2 2 0 012 2v14a2 2 0 01-2 2h-4"/><polyline points="10,17 15,12 10,7"/><line x1="15" y1="12" x2="3" y2="12"/></svg>Sign In
+    </a>
+  </div>
+</aside>
+
+<script>
+let currentUser=null;
+fetch('/auth/me',{credentials:'include'}).then(r=>r.ok?r.json():null).then(u=>{
+  if(!u)return;
+  currentUser=u;
+  document.getElementById('sidebarUser').style.display='flex';
+  document.getElementById('signoutLink').style.display='flex';
+  document.getElementById('signinLink').style.display='none';
+  document.getElementById('userName').textContent=u.name||u.email;
+  document.getElementById('userRoleLabel').textContent=u.role;
+  const av=document.getElementById('userAvatar');
+  if(u.avatar_url){av.innerHTML='<img src="'+u.avatar_url+'" style="width:100%;height:100%;border-radius:50%;object-fit:cover">';}
+  else{av.textContent=(u.name||u.email).charAt(0).toUpperCase();}
+  if(u.role==='admin'||u.role==='ceo'){
+    document.getElementById('sidebarRole').textContent='Admin Panel';
+  }
+}).catch(()=>{});
+</script>
+
+<div class="main-content">
+  <h1 class="page-title">Report a Bug</h1>
+  <p class="page-subtitle">Found something broken? Let us know and we'll fix it.</p>
+
+  <div class="form-card">
+    <div class="success-msg" id="successMsg">Bug report submitted! Thanks for helping us improve.</div>
+    <div class="error-msg" id="errorMsg"></div>
+
+    <div class="form-group">
+      <label class="form-label">Subject</label>
+      <input class="form-input" id="bugSubject" placeholder="Brief summary of the issue">
+    </div>
+    <div class="form-group">
+      <label class="form-label">Description</label>
+      <textarea class="form-textarea" id="bugDescription" placeholder="What happened? What did you expect to happen?"></textarea>
+    </div>
+    <div class="form-group">
+      <label class="form-label">Page URL / Job ID <span style="color:var(--dark)">(optional)</span></label>
+      <input class="form-input" id="bugPageUrl" placeholder="e.g. /my-jobs or a job ID">
+      <div class="form-hint">Auto-filled with current page if left blank</div>
+    </div>
+    <button class="form-btn" id="sendBtn" onclick="submitBug()">Submit Report</button>
+  </div>
+</div>
+</div>
+
+<script>
+async function submitBug(){
+  const subject=document.getElementById('bugSubject').value.trim();
+  const description=document.getElementById('bugDescription').value.trim();
+  const pageUrl=document.getElementById('bugPageUrl').value.trim()||window.location.href;
+  const errEl=document.getElementById('errorMsg');
+  const okEl=document.getElementById('successMsg');
+  errEl.style.display='none'; okEl.style.display='none';
+
+  if(!subject||!description){errEl.textContent='Please fill in subject and description.';errEl.style.display='block';return;}
+
+  const btn=document.getElementById('sendBtn');
+  btn.disabled=true; btn.textContent='Submitting...';
+  try{
+    const r=await fetch('/bugs',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({subject,description,page_url:pageUrl})});
+    if(!r.ok){const e=await r.json().catch(()=>({}));throw new Error(e.detail||'Failed to submit');}
+    okEl.style.display='block';
+    document.getElementById('bugSubject').value='';
+    document.getElementById('bugDescription').value='';
+    document.getElementById('bugPageUrl').value='';
+  }catch(e){errEl.textContent=e.message;errEl.style.display='block';}
+  finally{btn.disabled=false;btn.textContent='Submit Report';}
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

### Contact Us page (#42)
- New `/contact` page (public, no login required)
- Form: name, email, subject dropdown, message
- Auto-fills name/email for logged-in users
- `POST /contact` stores to `contact_messages` table
- `GET /contact/messages` admin endpoint to view all messages

### Report Bug page (#41)
- New `/report-bug` page (requires login)
- Form: subject, description, optional page URL (auto-filled)
- `POST /bugs` stores to `bug_reports` table with user_id
- `GET /bugs` admin endpoint to view all reports

### Task requeue verification (#34)
Code review confirms all acceptance criteria are met:
- Failed running tasks requeue with `claim_after` in the future
- Claim query skips tasks where `claim_after > NOW()`
- `claim_after` cleared on successful claim
- After `MAX_TASK_FAILURE_RETRIES` (5), task permanently fails
- API response includes `requeued`, `failed`, `failure_count`, `retry_delay_seconds`
- Config: `TASK_FAILURE_RETRY_DELAY_SECONDS=60`, `MAX_TASK_FAILURE_RETRIES=5`

## Test plan
- [ ] Visit `/contact` while logged out — form works, message submits
- [ ] Visit `/contact` while logged in — name/email auto-filled
- [ ] Visit `/report-bug` while logged out — redirects to `/login`
- [ ] Submit a bug report — verify it appears in `GET /bugs` (admin)
- [ ] Admin can view all contact messages at `GET /contact/messages`

Closes #41, Closes #42, Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)