### PR TITLE
Fix invisible headings on dark admin pages

### DIFF
--- a/frontend/web/src/app/components/admin-layout.tsx
+++ b/frontend/web/src/app/components/admin-layout.tsx
@@ -57,7 +57,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
   const filteredNavItems = navItems.filter(item => !item.adminOnly || isAdmin);
 
   return (
-    <div className="flex min-h-screen bg-gradient-to-br from-slate-950 via-blue-950 to-slate-950">
+    <div className="flex min-h-screen bg-gradient-to-br from-slate-950 via-blue-950 to-slate-950 text-white">
       {/* Animated background */}
       <div className="fixed inset-0 overflow-hidden pointer-events-none">
         <motion.div 


### PR DESCRIPTION
AdminLayout lacked text-white; body text-foreground is near-black from theme.css, so titles blended into the gradient.

Made with [Cursor](https://cursor.com)