### PR TITLE
Submit job: dataset sources (built-in, OpenML, CSV, upload)

### DIFF
--- a/backend/datasets.py
+++ b/backend/datasets.py
@@ -215,6 +215,10 @@ def list_datasets() -> list[dict]:
 
 _external_cache: dict[str, tuple[list[dict], dict]] = {}
 
+# Ephemeral server-side CSV uploads (single-instance demo; re-upload after restart)
+_upload_csv_store: dict[str, bytes] = {}
+MAX_CSV_UPLOAD_BYTES = 10 * 1024 * 1024
+
 
 def _infer_task_category(y_values: list, target_name: str) -> str:
     """Guess regression vs classification from target values."""
@@ -379,6 +383,80 @@ def load_csv_url(url: str, target: str | None = None) -> tuple[list[dict], dict]
     return rows, meta
 
 
+def store_csv_upload(data: bytes) -> str:
+    """Store raw CSV bytes; returns token for preview + job input_payload."""
+    import uuid
+
+    if len(data) > MAX_CSV_UPLOAD_BYTES:
+        raise ValueError(f"CSV too large (max {MAX_CSV_UPLOAD_BYTES // (1024 * 1024)} MB)")
+    if not data or not data.strip():
+        raise ValueError("CSV file is empty")
+    token = str(uuid.uuid4())
+    _upload_csv_store[token] = data
+    return token
+
+
+def load_csv_from_upload_token(token: str, target: str | None = None) -> tuple[list[dict], dict]:
+    """Load dataset from a prior store_csv_upload token."""
+    if token not in _upload_csv_store:
+        raise ValueError("Upload not found — re-upload your CSV file")
+    data = _upload_csv_store[token]
+    cache_key = f"csv_upload:{token}:{target}"
+    if cache_key in _external_cache:
+        return _external_cache[cache_key]
+
+    import pandas as pd
+
+    df = pd.read_csv(io.BytesIO(data))
+    if df.empty:
+        raise ValueError("CSV is empty or could not be parsed")
+    df.columns = [str(c).strip() for c in df.columns]
+
+    resolved_target = str(target) if target else str(df.columns[-1])
+    if resolved_target not in df.columns:
+        raise ValueError(
+            f"Target column '{resolved_target}' not found. Columns: {list(df.columns)}"
+        )
+
+    feature_cols = [c for c in df.columns if c != resolved_target]
+    if not feature_cols:
+        raise ValueError("No feature columns after selecting target")
+
+    work = df[feature_cols + [resolved_target]].dropna(how="any")
+    if work.empty:
+        raise ValueError("CSV has no rows after dropping NaNs")
+
+    if len(work) > MAX_ROWS:
+        work = work.sample(n=MAX_ROWS, random_state=42)
+
+    y_series = work[resolved_target]
+    if pd.api.types.is_numeric_dtype(y_series):
+        y_vals = y_series.astype(float).tolist()[:5000]
+    else:
+        y_vals = pd.factorize(y_series)[0].tolist()[:5000]
+    task_category = _infer_task_category(y_vals, resolved_target)
+
+    work_enc = work.copy()
+    for col in work_enc.columns:
+        s = work_enc[col]
+        if pd.api.types.is_numeric_dtype(s):
+            work_enc[col] = s.astype(float)
+        else:
+            work_enc[col] = pd.factorize(s)[0].astype(float)
+
+    rows = work_enc.to_dict("records")
+
+    meta = {
+        "target": resolved_target,
+        "task_category": task_category,
+        "all_features": feature_cols,
+        "display_name": "Uploaded CSV",
+        "description": f"{len(rows):,} rows, {len(feature_cols)} features",
+    }
+    _external_cache[cache_key] = (rows, meta)
+    return rows, meta
+
+
 def load_external_dataset(
     source: str, dataset_id: str, target: str | None = None
 ) -> tuple[list[dict], dict]:
@@ -387,6 +465,8 @@ def load_external_dataset(
         return load_openml(dataset_id, target=target)
     elif source == "csv_url":
         return load_csv_url(dataset_id, target=target)
+    elif source == "csv_upload":
+        return load_csv_from_upload_token(dataset_id, target=target)
     elif source == "built_in":
         return get_dataset(dataset_id)
     else:
@@ -490,6 +570,39 @@ def preview_dataset(
             "suggested_target": suggested_target,
             "suggested_task_category": task_cat,
             "display_name": dataset_id.split("/")[-1][:60] or "CSV",
+        }
+
+    if source == "csv_upload":
+        import pandas as pd
+
+        if dataset_id not in _upload_csv_store:
+            raise ValueError("Upload not found — upload the CSV again")
+        df = pd.read_csv(io.BytesIO(_upload_csv_store[dataset_id]))
+        if df.empty:
+            raise ValueError("CSV is empty")
+        df.columns = [str(c).strip() for c in df.columns]
+        all_cols = list(df.columns)
+        numeric = list(df.select_dtypes(include=["number"]).columns)
+        suggested_target = str(all_cols[-1])
+        y_series = df[suggested_target].dropna()
+        if len(y_series):
+            if pd.api.types.is_numeric_dtype(y_series):
+                y_vals = y_series.astype(float).tolist()[:5000]
+            else:
+                y_vals = pd.factorize(y_series)[0].tolist()[:5000]
+            task_cat = _infer_task_category(y_vals, suggested_target)
+        else:
+            task_cat = "regression"
+        sample = df.head(5).to_dict("records")
+        return {
+            "columns": all_cols,
+            "numeric_columns": numeric,
+            "target_columns": all_cols,
+            "row_count": len(df),
+            "sample_rows": sample,
+            "suggested_target": suggested_target,
+            "suggested_task_category": task_cat,
+            "display_name": "Uploaded CSV",
         }
 
     raise ValueError(f"Unknown source: {source}")

--- a/backend/handlers/ml_experiment.py
+++ b/backend/handlers/ml_experiment.py
@@ -58,7 +58,7 @@ def handle(task: dict, job: dict) -> str:
     source = payload.get("source", "built_in")
     dataset_id = payload.get("dataset_id", "")
 
-    if source in ("openml", "csv_url") and dataset_id:
+    if source in ("openml", "csv_url", "csv_upload") and dataset_id:
         rows, meta = load_external_dataset(source, dataset_id, target=target)
         target = meta["target"]
         task_category = meta["task_category"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ import httpx
 from urllib.parse import urlencode
 from uuid import UUID
 
-from fastapi import FastAPI, Request, HTTPException
+from fastapi import FastAPI, Request, HTTPException, File, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, RedirectResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -619,7 +619,28 @@ async def not_found_handler(request: Request, exc):
     return FileResponse(os.path.join(ERROR_DIR, "404.html"), status_code=404)
 
 
-# ── Dataset preview endpoint ─────────────────────────────────
+# ── Dataset APIs ─────────────────────────────────────────────
+@app.get("/datasets/built-in")
+async def list_builtin_datasets():
+    """Names and metadata for built-in synthetic datasets."""
+    from datasets import list_datasets
+
+    return list_datasets()
+
+
+@app.post("/datasets/csv-upload")
+async def upload_csv_dataset(file: UploadFile = File(...)):
+    """Store a CSV for preview + job submission (same server process)."""
+    data = await file.read()
+    try:
+        from datasets import store_csv_upload
+
+        token = store_csv_upload(data)
+    except ValueError as e:
+        return JSONResponse({"detail": str(e)}, status_code=400)
+    return {"token": token}
+
+
 @app.post("/datasets/load")
 async def load_dataset_preview(request: Request):
     """Preview a dataset before job submission. Returns columns, sample rows, suggested target."""

--- a/backend/planner.py
+++ b/backend/planner.py
@@ -32,7 +32,7 @@ def _plan_ml_experiment(input_payload: dict) -> list[dict]:
     dataset_id = input_payload.get("dataset_id", "")
     dataset_name = input_payload.get("dataset_name", "weather_ri")
 
-    if source in ("openml", "csv_url") and dataset_id:
+    if source in ("openml", "csv_url", "csv_upload") and dataset_id:
         from datasets import load_external_dataset
         target_override = input_payload.get("target")
         _, meta = load_external_dataset(source, dataset_id, target=target_override)

--- a/frontend/web/src/app/components/dataset-source-section.tsx
+++ b/frontend/web/src/app/components/dataset-source-section.tsx
@@ -1,0 +1,353 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Database, Globe, Link2, Upload, Loader2, Eye } from 'lucide-react';
+import { toast } from 'sonner';
+
+export type DatasetMode = 'built_in' | 'openml' | 'csv_url' | 'csv_upload';
+
+export type BuiltinDatasetMeta = {
+  name: string;
+  display_name: string;
+  description: string;
+  task_category: string;
+  target: string;
+};
+
+export type DatasetPreview = {
+  columns: string[];
+  row_count: number;
+  suggested_target: string;
+  suggested_task_category: string;
+  display_name: string;
+  sample_rows?: Record<string, unknown>[];
+};
+
+type Props = {
+  disabled?: boolean;
+  mode: DatasetMode;
+  onModeChange: (m: DatasetMode) => void;
+  builtInName: string;
+  onBuiltInNameChange: (name: string) => void;
+  openmlId: string;
+  onOpenmlIdChange: (v: string) => void;
+  csvUrl: string;
+  onCsvUrlChange: (v: string) => void;
+  uploadToken: string | null;
+  onUploadTokenChange: (t: string | null) => void;
+  targetOverride: string;
+  onTargetOverrideChange: (v: string) => void;
+};
+
+const tabs: { id: DatasetMode; label: string; icon: typeof Database }[] = [
+  { id: 'built_in', label: 'Built-in', icon: Database },
+  { id: 'openml', label: 'OpenML', icon: Globe },
+  { id: 'csv_url', label: 'CSV URL', icon: Link2 },
+  { id: 'csv_upload', label: 'Upload CSV', icon: Upload },
+];
+
+export function DatasetSourceSection({
+  disabled,
+  mode,
+  onModeChange,
+  builtInName,
+  onBuiltInNameChange,
+  openmlId,
+  onOpenmlIdChange,
+  csvUrl,
+  onCsvUrlChange,
+  uploadToken,
+  onUploadTokenChange,
+  targetOverride,
+  onTargetOverrideChange,
+}: Props) {
+  const [builtIns, setBuiltIns] = useState<BuiltinDatasetMeta[]>([]);
+  const [preview, setPreview] = useState<DatasetPreview | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [uploadBusy, setUploadBusy] = useState(false);
+
+  useEffect(() => {
+    fetch('/datasets/built-in', { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((rows: BuiltinDatasetMeta[]) => setBuiltIns(Array.isArray(rows) ? rows : []))
+      .catch(() => setBuiltIns([]));
+  }, []);
+
+  const runPreview = useCallback(async () => {
+    let source: string = mode;
+    let datasetId = '';
+    if (mode === 'built_in') {
+      source = 'built_in';
+      datasetId = builtInName;
+    } else if (mode === 'openml') {
+      datasetId = openmlId.trim();
+    } else if (mode === 'csv_url') {
+      datasetId = csvUrl.trim();
+    } else {
+      source = 'csv_upload';
+      datasetId = uploadToken || '';
+    }
+
+    if (!datasetId) {
+      toast.error('Choose or enter a dataset first');
+      return;
+    }
+
+    setPreviewLoading(true);
+    try {
+      const res = await fetch('/datasets/load', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ source, dataset_id: datasetId }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        const d = (err as { detail?: string }).detail;
+        throw new Error(typeof d === 'string' ? d : 'Preview failed');
+      }
+      const data = await res.json();
+      setPreview(data as DatasetPreview);
+      toast.success('Dataset loaded');
+    } catch (e) {
+      setPreview(null);
+      toast.error(e instanceof Error ? e.message : 'Preview failed');
+    } finally {
+      setPreviewLoading(false);
+    }
+  }, [mode, builtInName, openmlId, csvUrl, uploadToken]);
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    setUploadBusy(true);
+    onUploadTokenChange(null);
+    setPreview(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await fetch('/datasets/csv-upload', {
+        method: 'POST',
+        body: fd,
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error((err as { detail?: string }).detail || 'Upload failed');
+      }
+      const { token } = await res.json();
+      onUploadTokenChange(token);
+      toast.success('CSV uploaded — loading preview…');
+      setPreviewLoading(true);
+      const pr = await fetch('/datasets/load', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ source: 'csv_upload', dataset_id: token }),
+      });
+      if (!pr.ok) {
+        const err = await pr.json().catch(() => ({}));
+        throw new Error((err as { detail?: string }).detail || 'Preview failed');
+      }
+      setPreview(await pr.json());
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setUploadBusy(false);
+      setPreviewLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-slate-300 mb-2">Dataset source</label>
+        <div className="flex flex-wrap gap-2">
+          {tabs.map(({ id, label, icon: Icon }) => (
+            <button
+              key={id}
+              type="button"
+              disabled={disabled}
+              onClick={() => onModeChange(id)}
+              className={`inline-flex items-center gap-2 px-3 py-2 rounded-xl text-sm font-medium border transition-colors ${
+                mode === id
+                  ? 'bg-purple-500/20 border-purple-500/50 text-white'
+                  : 'bg-slate-800/40 border-white/10 text-slate-300 hover:border-white/20'
+              }`}
+            >
+              <Icon className="w-4 h-4 shrink-0" />
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {mode === 'built_in' && (
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-2">Built-in dataset</label>
+          <select
+            value={builtInName}
+            onChange={(e) => onBuiltInNameChange(e.target.value)}
+            disabled={disabled}
+            className="w-full px-4 py-3 rounded-xl bg-slate-800/50 border border-white/10 focus:border-purple-500/50 outline-none text-white"
+          >
+            {builtIns.length === 0 ? (
+              <option value="weather_ri">Rhode Island Weather (default)</option>
+            ) : (
+              builtIns.map((d) => (
+                <option key={d.name} value={d.name}>
+                  {d.display_name}
+                </option>
+              ))
+            )}
+          </select>
+          {builtIns.find((b) => b.name === builtInName) && (
+            <p className="mt-2 text-xs text-slate-500">
+              {builtIns.find((b) => b.name === builtInName)?.description}
+            </p>
+          )}
+        </div>
+      )}
+
+      {mode === 'openml' && (
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-2">OpenML dataset ID</label>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={openmlId}
+              onChange={(e) => onOpenmlIdChange(e.target.value)}
+              placeholder="e.g. 61 (Iris)"
+              disabled={disabled}
+              className="w-full px-4 py-3 rounded-xl bg-slate-800/50 border border-white/10 focus:border-purple-500/50 outline-none text-white placeholder:text-slate-500"
+            />
+            <p className="mt-1 text-xs text-slate-500">Numeric ID from openml.org</p>
+          </div>
+        </div>
+      )}
+
+      {mode === 'csv_url' && (
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-2">CSV URL</label>
+          <input
+            type="url"
+            value={csvUrl}
+            onChange={(e) => onCsvUrlChange(e.target.value)}
+            placeholder="https://…/data.csv"
+            disabled={disabled}
+            className="w-full px-4 py-3 rounded-xl bg-slate-800/50 border border-white/10 focus:border-purple-500/50 outline-none text-white placeholder:text-slate-500"
+          />
+          <p className="mt-1 text-xs text-slate-500">Public HTTPS URL to a CSV file</p>
+        </div>
+      )}
+
+      {mode === 'csv_upload' && (
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-2">CSV file</label>
+          <label className="flex flex-col items-center justify-center w-full px-4 py-8 rounded-xl border border-dashed border-white/20 bg-slate-800/30 cursor-pointer hover:border-purple-500/40 transition-colors">
+            <input type="file" accept=".csv,text/csv" className="hidden" disabled={disabled || uploadBusy} onChange={onFile} />
+            {uploadBusy ? (
+              <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
+            ) : (
+              <>
+                <Upload className="w-8 h-8 text-slate-400 mb-2" />
+                <span className="text-sm text-slate-300">Click to upload a .csv file</span>
+                {uploadToken && (
+                  <span className="mt-2 text-xs text-emerald-400 font-mono">Ready · token {uploadToken.slice(0, 8)}…</span>
+                )}
+              </>
+            )}
+          </label>
+        </div>
+      )}
+
+      {(mode === 'openml' || mode === 'csv_url' || mode === 'csv_upload') && (
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-2">
+            Target column <span className="text-slate-500 font-normal">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={targetOverride}
+            onChange={(e) => onTargetOverrideChange(e.target.value)}
+            placeholder="Override auto-detected target column"
+            disabled={disabled}
+            className="w-full px-4 py-3 rounded-xl bg-slate-800/50 border border-white/10 focus:border-purple-500/50 outline-none text-white placeholder:text-slate-500"
+          />
+        </div>
+      )}
+
+      {mode !== 'csv_upload' && (
+        <button
+          type="button"
+          disabled={disabled || previewLoading}
+          onClick={runPreview}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/10 hover:bg-white/15 border border-white/10 text-sm text-white transition-colors disabled:opacity-50"
+        >
+          {previewLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Eye className="w-4 h-4" />}
+          Preview dataset
+        </button>
+      )}
+
+      {preview && (
+        <div className="rounded-xl border border-white/10 bg-slate-950/50 p-4 space-y-2">
+          <p className="text-sm font-medium text-white">{preview.display_name}</p>
+          <p className="text-xs text-slate-400">
+            ~{preview.row_count.toLocaleString()} rows · {preview.columns.length} columns · target:{' '}
+            <code className="text-purple-300">{preview.suggested_target}</code> · {preview.suggested_task_category}
+          </p>
+          {preview.sample_rows && preview.sample_rows.length > 0 && (
+            <div className="mt-2 overflow-x-auto text-xs">
+              <table className="w-full border-collapse border border-white/10 rounded">
+                <thead>
+                  <tr className="bg-white/5">
+                    {preview.columns.slice(0, 6).map((c) => (
+                      <th key={c} className="text-left p-2 text-slate-400 font-medium border-b border-white/10">
+                        {c}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.sample_rows.slice(0, 3).map((row, i) => (
+                    <tr key={i}>
+                      {preview.columns.slice(0, 6).map((c) => (
+                        <td key={c} className="p-2 text-slate-300 border-b border-white/5">
+                          {String((row as Record<string, unknown>)[c] ?? '')}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function buildJobInputPayload(
+  mode: DatasetMode,
+  builtInName: string,
+  openmlId: string,
+  csvUrl: string,
+  uploadToken: string | null,
+  targetOverride: string,
+): Record<string, unknown> {
+  const t = targetOverride.trim();
+  const target = t ? { target: t } : {};
+  switch (mode) {
+    case 'built_in':
+      return { source: 'built_in', dataset_name: builtInName, dataset_id: '', ...target };
+    case 'openml':
+      return { source: 'openml', dataset_id: openmlId.trim(), ...target };
+    case 'csv_url':
+      return { source: 'csv_url', dataset_id: csvUrl.trim(), ...target };
+    case 'csv_upload':
+      return { source: 'csv_upload', dataset_id: uploadToken || '', ...target };
+    default:
+      return {};
+  }
+}

--- a/frontend/web/src/app/pages/submit-job.tsx
+++ b/frontend/web/src/app/pages/submit-job.tsx
@@ -1,6 +1,11 @@
 import { AdminLayout } from '../components/admin-layout';
+import {
+  DatasetSourceSection,
+  buildJobInputPayload,
+  type DatasetMode,
+} from '../components/dataset-source-section';
 import { motion } from 'motion/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Sparkles, Loader2, CheckCircle2, AlertCircle, Wallet } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -25,6 +30,19 @@ export function SubmitJobPage() {
   const [estLoading, setEstLoading] = useState(true);
   const [estError, setEstError] = useState<string | null>(null);
 
+  const [datasetMode, setDatasetMode] = useState<DatasetMode>('built_in');
+  const [builtInName, setBuiltInName] = useState('weather_ri');
+  const [openmlId, setOpenmlId] = useState('');
+  const [csvUrl, setCsvUrl] = useState('');
+  const [uploadToken, setUploadToken] = useState<string | null>(null);
+  const [targetOverride, setTargetOverride] = useState('');
+
+  const inputPayload = useMemo(
+    () =>
+      buildJobInputPayload(datasetMode, builtInName, openmlId, csvUrl, uploadToken, targetOverride),
+    [datasetMode, builtInName, openmlId, csvUrl, uploadToken, targetOverride],
+  );
+
   useEffect(() => {
     let cancelled = false;
     setEstLoading(true);
@@ -40,7 +58,7 @@ export function SubmitJobPage() {
               title: title.trim() || 'Preview',
               description: description || '',
               task_type: taskType,
-              input_payload: {},
+              input_payload: inputPayload,
             }),
           });
           if (!res.ok) {
@@ -70,13 +88,25 @@ export function SubmitJobPage() {
       cancelled = true;
       clearTimeout(t);
     };
-  }, [title, description, taskType]);
+  }, [title, description, taskType, inputPayload]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
     if (!title.trim() || !description.trim()) {
       toast.error('Please fill in all fields');
+      return;
+    }
+    if (datasetMode === 'openml' && !openmlId.trim()) {
+      toast.error('Enter an OpenML dataset ID');
+      return;
+    }
+    if (datasetMode === 'csv_url' && !csvUrl.trim()) {
+      toast.error('Enter a CSV URL');
+      return;
+    }
+    if (datasetMode === 'csv_upload' && !uploadToken) {
+      toast.error('Upload a CSV file');
       return;
     }
 
@@ -90,7 +120,7 @@ export function SubmitJobPage() {
           title,
           description,
           task_type: taskType,
-          input_payload: {},
+          input_payload: inputPayload,
         })
       });
 
@@ -180,6 +210,25 @@ export function SubmitJobPage() {
                       More task types ship when planners are enabled server-side.
                     </p>
                   </div>
+
+                  <DatasetSourceSection
+                    disabled={loading}
+                    mode={datasetMode}
+                    onModeChange={(m) => {
+                      setDatasetMode(m);
+                      if (m !== 'csv_upload') setUploadToken(null);
+                    }}
+                    builtInName={builtInName}
+                    onBuiltInNameChange={setBuiltInName}
+                    openmlId={openmlId}
+                    onOpenmlIdChange={setOpenmlId}
+                    csvUrl={csvUrl}
+                    onCsvUrlChange={setCsvUrl}
+                    uploadToken={uploadToken}
+                    onUploadTokenChange={setUploadToken}
+                    targetOverride={targetOverride}
+                    onTargetOverrideChange={setTargetOverride}
+                  />
 
                   {/* Description */}
                   <div>


### PR DESCRIPTION
- Restores legacy-style dataset selection on submit\n- New APIs: GET /datasets/built-in, POST /datasets/csv-upload\n- csv_upload token flow for local CSV files (in-memory, single instance)

Made with [Cursor](https://cursor.com)