### PR TITLE
fix: add python-multipart for Render deploy

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+python-multipart
 uvicorn
 asyncpg
 python-dotenv


### PR DESCRIPTION
Required when using UploadFile on POST /datasets/csv-upload; FastAPI raises at import without it.

Made with [Cursor](https://cursor.com)