### PR TITLE
feat: private local LLM chat (issue #89)

### DIFF
--- a/backend/apis/chat.py
+++ b/backend/apis/chat.py
@@ -1,0 +1,234 @@
+import json
+from fastapi import APIRouter, HTTPException, Request
+from database import get_pool
+from auth import get_session, ELEVATED_ROLES
+
+
+router = APIRouter()
+
+
+async def _require_job_access(conn, request: Request, job_id: str) -> dict:
+    user = await get_session(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    job = await conn.fetchrow("SELECT id, user_id, task_type, status FROM jobs WHERE id = $1::uuid", job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job["task_type"] != "local_llm_chat":
+        raise HTTPException(status_code=400, detail="Not a local_llm_chat job")
+
+    is_owner = (str(job["user_id"]) if job["user_id"] is not None else None) == user["id"]
+    is_admin = user.get("role") in ELEVATED_ROLES
+    if not is_owner and not is_admin:
+        raise HTTPException(status_code=403, detail="You can only access your own chat jobs")
+
+    return dict(job)
+
+
+@router.get("/chat/{job_id}/messages")
+async def get_chat_messages(job_id: str, after_seq: int = 0, request: Request | None = None) -> list[dict]:
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        if request is None:
+            raise HTTPException(status_code=400, detail="Missing request")
+        await _require_job_access(conn, request, job_id)
+
+        rows = await conn.fetch(
+            """
+            SELECT seq, role, content, created_at
+            FROM chat_messages
+            WHERE job_id = $1::uuid AND seq > $2
+            ORDER BY seq ASC
+            """,
+            job_id,
+            after_seq,
+        )
+        return [dict(r) for r in rows]
+
+
+@router.get("/chat/worker/{job_id}/messages")
+async def worker_get_chat_messages(job_id: str, after_seq: int = 0) -> list[dict]:
+    """
+    Worker-facing message feed.
+
+    This endpoint is intentionally unauthenticated so workers can poll for new user messages
+    while executing the local inference loop.
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        job = await conn.fetchrow("SELECT id, task_type FROM jobs WHERE id = $1::uuid", job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+        if job["task_type"] != "local_llm_chat":
+            raise HTTPException(status_code=400, detail="Not a local_llm_chat job")
+
+        rows = await conn.fetch(
+            """
+            SELECT seq, role, content, created_at
+            FROM chat_messages
+            WHERE job_id = $1::uuid AND seq > $2
+            ORDER BY seq ASC
+            """,
+            job_id,
+            after_seq,
+        )
+        return [dict(r) for r in rows]
+
+
+@router.post("/chat/{job_id}/message")
+async def post_user_message(job_id: str, request: Request) -> dict:
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON") from None
+
+    content = (body.get("content") or "").strip()
+    if not content:
+        raise HTTPException(status_code=400, detail="content is required")
+    if len(content) > 4000:
+        raise HTTPException(status_code=400, detail="content too long (max 4000 chars)")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        await _require_job_access(conn, request, job_id)
+
+        # Next seq is max(seq)+1 within job.
+        next_seq = await conn.fetchval(
+            "SELECT COALESCE(MAX(seq), 0) + 1 FROM chat_messages WHERE job_id = $1::uuid",
+            job_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO chat_messages (job_id, seq, role, content)
+            VALUES ($1::uuid, $2, 'user', $3)
+            """,
+            job_id,
+            next_seq,
+            content,
+        )
+        await conn.execute(
+            """
+            INSERT INTO job_events (job_id, event_type, message)
+            VALUES ($1::uuid, 'chat_user_message', $2)
+            """,
+            job_id,
+            f"User message received (seq={next_seq})",
+        )
+
+    return {"ok": True, "seq": int(next_seq)}
+
+
+# ── Worker-facing streaming helpers (no user auth) ─────────────────
+
+@router.post("/chat/worker/{job_id}/assistant/start")
+async def worker_start_assistant_message(job_id: str, request: Request) -> dict:
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON") from None
+    worker_node_id = (body.get("worker_node_id") or "").strip()
+    if not worker_node_id:
+        raise HTTPException(status_code=400, detail="worker_node_id is required")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        job = await conn.fetchrow("SELECT id, task_type FROM jobs WHERE id = $1::uuid", job_id)
+        if not job:
+            raise HTTPException(status_code=404, detail="Job not found")
+        if job["task_type"] != "local_llm_chat":
+            raise HTTPException(status_code=400, detail="Not a local_llm_chat job")
+
+        next_seq = await conn.fetchval(
+            "SELECT COALESCE(MAX(seq), 0) + 1 FROM chat_messages WHERE job_id = $1::uuid",
+            job_id,
+        )
+        await conn.execute(
+            """
+            INSERT INTO chat_messages (job_id, seq, role, content)
+            VALUES ($1::uuid, $2, 'assistant', '')
+            """,
+            job_id,
+            next_seq,
+        )
+        await conn.execute(
+            """
+            INSERT INTO job_events (job_id, event_type, message)
+            VALUES ($1::uuid, 'chat_assistant_start', $2)
+            """,
+            job_id,
+            f"Worker {worker_node_id[:8]} started assistant response (seq={next_seq})",
+        )
+
+    return {"ok": True, "seq": int(next_seq)}
+
+
+@router.post("/chat/worker/{job_id}/assistant/chunk")
+async def worker_append_assistant_chunk(job_id: str, request: Request) -> dict:
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON") from None
+
+    worker_node_id = (body.get("worker_node_id") or "").strip()
+    seq = body.get("seq")
+    chunk = body.get("chunk")
+    if not worker_node_id:
+        raise HTTPException(status_code=400, detail="worker_node_id is required")
+    if not isinstance(seq, int) or seq <= 0:
+        raise HTTPException(status_code=400, detail="seq must be a positive integer")
+    if not isinstance(chunk, str) or not chunk:
+        raise HTTPException(status_code=400, detail="chunk is required")
+    if len(chunk) > 2000:
+        raise HTTPException(status_code=400, detail="chunk too long")
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        updated = await conn.execute(
+            """
+            UPDATE chat_messages
+            SET content = content || $3
+            WHERE job_id = $1::uuid AND seq = $2 AND role = 'assistant'
+            """,
+            job_id,
+            seq,
+            chunk,
+        )
+        # best-effort event (not for every token; workers can throttle)
+        if updated:
+            pass
+
+    return {"ok": True}
+
+
+@router.post("/chat/worker/{job_id}/event")
+async def worker_chat_event(job_id: str, request: Request) -> dict:
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON") from None
+    worker_node_id = (body.get("worker_node_id") or "").strip()
+    event_type = (body.get("event_type") or "").strip()
+    message = (body.get("message") or "").strip()
+    if not worker_node_id:
+        raise HTTPException(status_code=400, detail="worker_node_id is required")
+    if not event_type:
+        raise HTTPException(status_code=400, detail="event_type is required")
+    if not message:
+        raise HTTPException(status_code=400, detail="message is required")
+    if len(message) > 4000:
+        message = message[:4000] + "…"
+
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO job_events (job_id, event_type, message)
+            VALUES ($1::uuid, $2, $3)
+            """,
+            job_id,
+            f"chat_{event_type}",
+            f"[{worker_node_id[:8]}] {message}",
+        )
+    return {"ok": True}
+

--- a/backend/apis/chat.py
+++ b/backend/apis/chat.py
@@ -27,11 +27,9 @@ async def _require_job_access(conn, request: Request, job_id: str) -> dict:
 
 
 @router.get("/chat/{job_id}/messages")
-async def get_chat_messages(job_id: str, after_seq: int = 0, request: Request | None = None) -> list[dict]:
+async def get_chat_messages(request: Request, job_id: str, after_seq: int = 0) -> list[dict]:
     pool = await get_pool()
     async with pool.acquire() as conn:
-        if request is None:
-            raise HTTPException(status_code=400, detail="Missing request")
         await _require_job_access(conn, request, job_id)
 
         rows = await conn.fetch(

--- a/backend/config.py
+++ b/backend/config.py
@@ -30,6 +30,7 @@ SESSION_MAX_AGE_SECONDS: int = 86400  # 24 hours
 # ── Task Types ───────────────────────────────────────────────
 VALID_TASK_TYPES: set[str] = {
     "ml_experiment",
+    "local_llm_chat",
 }
 
 # ── Job Constraints ──────────────────────────────────────────
@@ -42,6 +43,8 @@ MIN_REWARD: float = 0.0
 # Kept low so DCN undercuts self-hosted cloud compute for convenience
 BASE_RATES: dict[str, float] = {
     "ml_experiment": 0.0001,
+    # Chat sessions are priced low for the demo (cost is mostly worker time).
+    "local_llm_chat": 0.00005,
 }
 # Multiplier applied based on minimum worker tier required
 TIER_MULTIPLIER: dict[int, float] = {1: 1.0, 2: 1.2, 3: 1.5, 4: 2.0}

--- a/backend/handlers/local_llm_chat.py
+++ b/backend/handlers/local_llm_chat.py
@@ -1,0 +1,190 @@
+import json
+import time
+from typing import Any
+
+import requests
+
+
+OLLAMA_BASE = "http://localhost:11434"
+
+
+def _backend_base(job: dict) -> str:
+    # In the demo worker, BASE_URL is set in the worker process, but handlers don't see it.
+    # So we read it from environment if present, else fall back to production.
+    import os
+
+    return os.getenv("DCN_BASE_URL") or os.getenv("BASE_URL") or "https://dcn-demo.onrender.com"
+
+
+def _post_event(base_url: str, job_id: str, worker_node_id: str, event_type: str, message: str) -> None:
+    try:
+        requests.post(
+            f"{base_url}/chat/worker/{job_id}/event",
+            json={
+                "worker_node_id": worker_node_id,
+                "event_type": event_type,
+                "message": message,
+            },
+            timeout=10,
+        )
+    except Exception:
+        pass
+
+
+def _start_assistant_message(base_url: str, job_id: str, worker_node_id: str) -> int:
+    resp = requests.post(
+        f"{base_url}/chat/worker/{job_id}/assistant/start",
+        json={"worker_node_id": worker_node_id},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return int(resp.json()["seq"])
+
+
+def _append_chunk(base_url: str, job_id: str, worker_node_id: str, seq: int, chunk: str) -> None:
+    requests.post(
+        f"{base_url}/chat/worker/{job_id}/assistant/chunk",
+        json={"worker_node_id": worker_node_id, "seq": seq, "chunk": chunk},
+        timeout=10,
+    )
+
+
+def _ollama_stream_chat(model: str, messages: list[dict[str, str]]) -> Any:
+    """
+    Yield assistant text chunks from Ollama /api/chat streaming responses.
+    """
+    r = requests.post(
+        f"{OLLAMA_BASE}/api/chat",
+        json={"model": model, "messages": messages, "stream": True},
+        stream=True,
+        timeout=120,
+    )
+    r.raise_for_status()
+    for line in r.iter_lines(decode_unicode=True):
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except Exception:
+            continue
+        if data.get("done"):
+            break
+        msg = data.get("message") or {}
+        chunk = msg.get("content") or ""
+        if chunk:
+            yield chunk
+
+
+def handle(task: dict, job: dict) -> str:
+    """
+    Long-running chat session handler.
+
+    Contract:
+    - Reads user messages from coordinator via /chat/{job_id}/messages polling.
+    - Generates assistant responses locally (Ollama) and streams chunks back via worker endpoints.
+    - Returns a short final transcript summary in result_text.
+    """
+    task_payload = task.get("task_payload") or {}
+    if isinstance(task_payload, str):
+        try:
+            task_payload = json.loads(task_payload)
+        except Exception:
+            task_payload = {}
+
+    job_id = str(task.get("job_id") or "")
+    worker_node_id = str(task.get("worker_node_id") or "")
+    base_url = _backend_base(job)
+
+    model = str(task_payload.get("model") or "llama3.1")
+    idle_timeout_seconds = int(task_payload.get("idle_timeout_seconds") or 300)
+    max_duration_seconds = int(task_payload.get("max_duration_seconds") or 1800)
+    system_prompt = (task_payload.get("system_prompt") or "").strip()
+
+    conversation: list[dict[str, str]] = []
+    if system_prompt:
+        conversation.append({"role": "system", "content": system_prompt})
+
+    _post_event(base_url, job_id, worker_node_id, "session_start", f"Chat session started (model={model})")
+
+    start_ts = time.time()
+    last_user_ts = time.time()
+    last_seq = 0
+    transcript_pairs: list[tuple[str, str]] = []
+
+    # Poll loop: stop on max duration or idle timeout
+    while True:
+        now = time.time()
+        if now - start_ts > max_duration_seconds:
+            _post_event(base_url, job_id, worker_node_id, "session_end", "Max duration reached; ending session.")
+            break
+        if now - last_user_ts > idle_timeout_seconds:
+            _post_event(base_url, job_id, worker_node_id, "session_end", "Idle timeout reached; ending session.")
+            break
+
+        # Pull any new messages
+        try:
+            resp = requests.get(
+                f"{base_url}/chat/worker/{job_id}/messages",
+                params={"after_seq": last_seq},
+                timeout=15,
+            )
+            rows = resp.json() if resp.status_code == 200 else []
+        except Exception:
+            rows = []
+
+        # Process all new user messages; ignore assistant/system rows (those were streamed by us)
+        new_user = [r for r in rows if r.get("role") == "user"]
+        if not new_user:
+            time.sleep(1.0)
+            continue
+
+        for r in new_user:
+            seq = int(r.get("seq") or 0)
+            content = str(r.get("content") or "")
+            if seq <= last_seq:
+                continue
+            last_seq = seq
+            last_user_ts = time.time()
+
+            conversation.append({"role": "user", "content": content})
+            _post_event(base_url, job_id, worker_node_id, "user", f"User message seq={seq}")
+
+            # Start assistant row and stream chunks into it.
+            try:
+                assistant_seq = _start_assistant_message(base_url, job_id, worker_node_id)
+            except Exception as e:
+                _post_event(base_url, job_id, worker_node_id, "error", f"Failed to start assistant message: {e}")
+                return f"Chat failed to start assistant message: {e}"
+
+            assistant_text = ""
+            try:
+                for chunk in _ollama_stream_chat(model=model, messages=conversation):
+                    assistant_text += chunk
+                    try:
+                        _append_chunk(base_url, job_id, worker_node_id, assistant_seq, chunk)
+                    except Exception:
+                        # If streaming back fails, we still keep generating and end with a full result.
+                        pass
+                conversation.append({"role": "assistant", "content": assistant_text})
+                transcript_pairs.append((content, assistant_text))
+            except requests.RequestException as e:
+                _post_event(base_url, job_id, worker_node_id, "error", f"Ollama error: {e}")
+                return f"Ollama error: {e}"
+
+        # Keep loop alive for more turns
+
+    # Return a compact transcript for job result
+    lines: list[str] = []
+    lines.append("Local LLM chat session finished.")
+    lines.append(f"- model: {model}")
+    lines.append(f"- turns: {len(transcript_pairs)}")
+    lines.append("")
+    for i, (u, a) in enumerate(transcript_pairs[-5:], 1):
+        lines.append(f"### Turn {i}")
+        lines.append(f"User: {u}")
+        lines.append("")
+        lines.append(f"Assistant: {a}")
+        lines.append("")
+
+    return "\n".join(lines).strip()
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from database import get_pool, close_pool
 from apis.jobs import router as jobs_router
 from apis.monitor import router as monitor_router
 from apis.workers import router as workers_router
+from apis.chat import router as chat_router
 from apis.feedback import router as feedback_router
 from apis.billing import router as billing_router
 from auth import (
@@ -370,6 +371,18 @@ async def lifespan(app: FastAPI):
                 created_at  TIMESTAMPTZ DEFAULT now()
             );
         """)
+        # ── Local LLM chat (issue #89) ────────────────────────────
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS chat_messages (
+                id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                job_id          UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+                seq             INTEGER NOT NULL,
+                role            TEXT NOT NULL CHECK (role IN ('system','user','assistant')),
+                content         TEXT NOT NULL DEFAULT '',
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            );
+            CREATE INDEX IF NOT EXISTS idx_chat_messages_job_seq ON chat_messages(job_id, seq);
+        """)
         # Performance indexes (safe to re-run)
         await conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_jobs_user_id ON jobs(user_id);
@@ -395,6 +408,7 @@ app.add_middleware(
 app.include_router(jobs_router)
 app.include_router(monitor_router)
 app.include_router(workers_router)
+app.include_router(chat_router)
 app.include_router(feedback_router)
 app.include_router(billing_router)
 

--- a/backend/planner.py
+++ b/backend/planner.py
@@ -16,6 +16,9 @@ def plan_tasks(task_type: str, input_payload: dict) -> list[dict]:
     if task_type == "ml_experiment":
         return _plan_ml_experiment(input_payload)
 
+    if task_type == "local_llm_chat":
+        return _plan_local_llm_chat(input_payload)
+
     else:
         return [
             {"task_name": f"step_{i}", "task_description": f"Subtask {i} for {task_type}", "task_payload": {}}
@@ -298,3 +301,31 @@ def _plan_ml_experiment(input_payload: dict) -> list[dict]:
                 "task_payload": {**base, "experiment_type": "extra_trees_classifier", "features": all_features, "cv_folds": 5, "params": {"n_estimators": 500, "max_depth": 20}, "min_tier": 4},
             },
         ]
+
+
+def _plan_local_llm_chat(input_payload: dict) -> list[dict]:
+    """
+    Plan a single long-running chat session task.
+
+    The worker is expected to run local inference (e.g. Ollama) and stream
+    assistant tokens back to the coordinator via chat APIs.
+    """
+    model = input_payload.get("model", "llama3.1")
+    idle_timeout_seconds = int(input_payload.get("idle_timeout_seconds", 5 * 60))
+    max_duration_seconds = int(input_payload.get("max_duration_seconds", 30 * 60))
+    system_prompt = input_payload.get("system_prompt", "").strip()
+
+    return [
+        {
+            "task_name": "chat_session",
+            "task_description": f"Run a streaming chat session with local model '{model}'",
+            "task_payload": {
+                "task_type": "local_llm_chat",
+                "model": model,
+                "idle_timeout_seconds": idle_timeout_seconds,
+                "max_duration_seconds": max_duration_seconds,
+                "system_prompt": system_prompt,
+                "min_tier": 1,
+            },
+        }
+    ]

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -23,10 +23,10 @@ def estimate_job_cost(subtasks: list[dict]) -> dict:
 
     for task in subtasks:
         payload = task.get("task_payload", {})
-        task_type = payload.get("experiment_type", "ml_experiment")
+        task_type = payload.get("task_type") or payload.get("experiment_type") or "ml_experiment"
         min_tier = payload.get("min_tier", 2)
 
-        base_rate = BASE_RATES.get("ml_experiment", 0.01)
+        base_rate = BASE_RATES.get(task_type, BASE_RATES.get("ml_experiment", 0.01))
         tier_mult = TIER_MULTIPLIER.get(min_tier, 1.0)
         est_seconds = ESTIMATED_SECONDS_PER_TIER.get(min_tier, 10)
 
@@ -72,7 +72,8 @@ def calculate_actual_cost(task_rows: list[dict]) -> dict:
                 payload = {}
 
         min_tier = payload.get("min_tier", 2)
-        base_rate = BASE_RATES.get("ml_experiment", 0.01)
+        task_type = payload.get("task_type") or payload.get("experiment_type") or "ml_experiment"
+        base_rate = BASE_RATES.get(task_type, BASE_RATES.get("ml_experiment", 0.01))
         tier_mult = TIER_MULTIPLIER.get(min_tier, 1.0)
 
         task_cost = round(base_rate * tier_mult * exec_time, 4)

--- a/backend/workers/worker.py
+++ b/backend/workers/worker.py
@@ -25,12 +25,15 @@ logger = logging.getLogger("dcn.worker")
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from handlers import ml_experiment
+from handlers import local_llm_chat
 from config import RETRY_BACKOFF_SECONDS, RATE_LIMIT_BACKOFF_MULTIPLIER, WORKER_POLL_INTERVAL_SECONDS
 
 BASE_URL = "https://dcn-demo.onrender.com"
 
 # Tell Gemini client where to find the cache server
 os.environ["DCN_CACHE_URL"] = BASE_URL
+# Tell chat handler where to find the coordinator
+os.environ["DCN_BASE_URL"] = BASE_URL
 
 
 def detect_worker_tier():
@@ -105,6 +108,7 @@ WORKER_TIER = detect_worker_tier()
 # Map task_type -> handler
 HANDLERS = {
     "ml_experiment": ml_experiment.handle,
+    "local_llm_chat": local_llm_chat.handle,
 }
 
 
@@ -122,6 +126,7 @@ def heartbeat(worker_node_id):
 
 AI_TASK_TYPES = [
     "ml_experiment",
+    "local_llm_chat",
 ]
 
 

--- a/frontend/web/src/app/components/admin-layout.tsx
+++ b/frontend/web/src/app/components/admin-layout.tsx
@@ -14,6 +14,7 @@ import {
   Bug,
   Settings,
   BarChart3,
+  MessageSquare,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { ReactNode, useEffect, useState } from 'react';
@@ -47,6 +48,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
   const navItems = [
     { path: '/submit', label: 'Submit Job', icon: Plus },
     { path: '/dashboard', label: 'Dashboard', icon: BarChart3 },
+    { path: '/chat', label: 'Chat', icon: MessageSquare },
     { path: '/ops', label: 'Ops', icon: LayoutDashboard, adminOnly: true },
     { path: '/jobs', label: 'All jobs', icon: FileText, adminOnly: true },
     { path: '/worker-logs', label: 'Worker Logs', icon: Monitor, adminOnly: true },

--- a/frontend/web/src/app/components/page-layout.tsx
+++ b/frontend/web/src/app/components/page-layout.tsx
@@ -67,6 +67,9 @@ export function PageLayout({ children, showAuth = true }: PageLayoutProps) {
                 <Link to="/my-jobs" className="text-slate-300 hover:text-white transition-colors text-sm font-medium">
                   My Jobs
                 </Link>
+                <Link to="/chat" className="text-slate-300 hover:text-white transition-colors text-sm font-medium">
+                  Chat
+                </Link>
                 <Link to="/ops" className="text-slate-300 hover:text-white transition-colors text-sm font-medium">
                   Monitor
                 </Link>

--- a/frontend/web/src/app/pages/chat.tsx
+++ b/frontend/web/src/app/pages/chat.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AdminLayout } from "../components/admin-layout";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { useRequireAuth } from "../hooks/use-require-auth";
+
+type ChatMsg = {
+  seq: number;
+  role: "system" | "user" | "assistant";
+  content: string;
+  created_at: string;
+};
+
+export function ChatPage() {
+  const { ready } = useRequireAuth();
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMsg[]>([]);
+  const [afterSeq, setAfterSeq] = useState<number>(0);
+  const [input, setInput] = useState("");
+  const [starting, setStarting] = useState(false);
+  const [sending, setSending] = useState(false);
+
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const scrollToBottom = () => bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  const lastSeq = useMemo(() => {
+    if (!messages.length) return 0;
+    return Math.max(...messages.map((m) => m.seq));
+  }, [messages]);
+
+  useEffect(() => {
+    setAfterSeq(lastSeq);
+  }, [lastSeq]);
+
+  const startChat = async () => {
+    setStarting(true);
+    try {
+      const res = await fetch("/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          title: "Private local LLM chat",
+          description: "Streaming chat session powered by worker-local inference.",
+          task_type: "local_llm_chat",
+          input_payload: {
+            model: "llama3.1",
+            idle_timeout_seconds: 300,
+            max_duration_seconds: 1800,
+            system_prompt: "You are a helpful assistant. Keep answers concise.",
+          },
+          priority: 2,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error((err as { detail?: string }).detail || "Failed to start chat");
+      }
+      const data = await res.json();
+      const id = data.job_id || data.id;
+      setJobId(id);
+      setMessages([]);
+      setAfterSeq(0);
+      toast.success("Chat session started");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to start chat");
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const sendMessage = async () => {
+    if (!jobId) return;
+    const content = input.trim();
+    if (!content) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/chat/${jobId}/message`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ content }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error((err as { detail?: string }).detail || "Send failed");
+      }
+      setInput("");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Send failed");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!ready || !jobId) return;
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`/chat/${jobId}/messages?after_seq=${afterSeq}`, {
+          credentials: "include",
+        });
+        if (!res.ok) return;
+        const data: ChatMsg[] = await res.json();
+        if (cancelled || !data.length) return;
+
+        // Merge by seq (assistant content may grow while streaming).
+        setMessages((prev) => {
+          const map = new Map<number, ChatMsg>();
+          for (const m of prev) map.set(m.seq, m);
+          for (const m of data) map.set(m.seq, m);
+          return Array.from(map.values()).sort((a, b) => a.seq - b.seq);
+        });
+      } catch {
+        // ignore
+      }
+    };
+
+    const t = setInterval(poll, 900);
+    poll();
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [ready, jobId, afterSeq]);
+
+  if (!ready) {
+    return (
+      <AdminLayout>
+        <div className="flex items-center justify-center min-h-[50vh]">
+          <Loader2 className="w-8 h-8 text-purple-400 animate-spin" />
+        </div>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <div className="container mx-auto px-6 py-10 max-w-4xl">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-white">Private local LLM chat</h1>
+          <p className="text-slate-400 mt-2">
+            Starts a long-running job. A worker runs local inference and streams tokens back into this page.
+          </p>
+        </div>
+
+        {!jobId ? (
+          <div className="rounded-2xl border border-white/10 bg-slate-900/50 backdrop-blur-xl p-6">
+            <Button onClick={startChat} disabled={starting}>
+              {starting ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Starting…
+                </>
+              ) : (
+                "Start chat session"
+              )}
+            </Button>
+            <p className="text-xs text-slate-500 mt-3">
+              Requires at least one worker running with Ollama on `localhost:11434`.
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-white/10 bg-slate-900/50 backdrop-blur-xl p-4">
+            <div className="text-xs text-slate-500 px-2 pb-3">
+              Job: <span className="font-mono text-slate-300">{jobId}</span>
+            </div>
+
+            <div className="h-[55vh] overflow-y-auto px-2 pb-2 space-y-3">
+              {messages.length === 0 ? (
+                <div className="text-sm text-slate-400">No messages yet. Send the first message to begin.</div>
+              ) : (
+                messages.map((m) => (
+                  <div
+                    key={m.seq}
+                    className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}
+                  >
+                    <div
+                      className={`max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-relaxed border ${
+                        m.role === "user"
+                          ? "bg-purple-500/15 border-purple-500/30 text-slate-100"
+                          : "bg-white/5 border-white/10 text-slate-200"
+                      }`}
+                    >
+                      <div className="text-[10px] uppercase tracking-wider opacity-60 mb-1">
+                        {m.role}
+                      </div>
+                      <div className="whitespace-pre-wrap">{m.content}</div>
+                    </div>
+                  </div>
+                ))
+              )}
+              <div ref={bottomRef} />
+            </div>
+
+            <div className="pt-3 flex gap-2">
+              <Input
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Type a message…"
+                disabled={sending}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") sendMessage();
+                }}
+              />
+              <Button onClick={sendMessage} disabled={sending || !input.trim()}>
+                {sending ? <Loader2 className="w-4 h-4 animate-spin" /> : "Send"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}
+

--- a/frontend/web/src/app/routes.tsx
+++ b/frontend/web/src/app/routes.tsx
@@ -8,6 +8,7 @@ import { Navigate, useLocation } from "react-router";
 import { AllJobsPage } from "./pages/all-jobs";
 import { AccountPage } from "./pages/account";
 import { PricingPage } from "./pages/pricing";
+import { ChatPage } from "./pages/chat";
 
 function RedirectResultsToJobs() {
   const { hash } = useLocation();
@@ -49,6 +50,10 @@ export const router = createBrowserRouter([
   {
     path: "/my-jobs",
     Component: MyJobsPage,
+  },
+  {
+    path: "/chat",
+    Component: ChatPage,
   },
   {
     path: "/ops",


### PR DESCRIPTION
## Summary
- Adds `local_llm_chat` as a first-class job/task type.
- Implements a coordinator-backed chat message store (`chat_messages`) and chat APIs.
- Adds a worker handler that runs **local Ollama inference** and streams assistant output back in chunks.
- Adds a new `/chat` page to start a session and send messages with near-real-time streaming updates.

## Demo notes
- Start a chat at `/chat`.
- Run at least one worker (`backend/workers/worker.py`) on a machine with Ollama listening on `http://localhost:11434`.
- Watch live events on `/ops` as messages stream.

## Safety limits
- Idle timeout: 5 minutes (configurable via job input payload)
- Max duration: 30 minutes (configurable via job input payload)

## Test plan
- [ ] Start session from `/chat` and verify job is created
- [ ] Send a message and confirm assistant output streams in the UI
- [ ] Verify `/ops` shows `chat_*` events while streaming
- [ ] Confirm session ends after idle timeout (no new messages)

Closes #89

Made with [Cursor](https://cursor.com)